### PR TITLE
Restore agent_data for DuckDB 1.5.2 community builds

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -15,10 +15,10 @@ concurrency:
 jobs:
   duckdb-stable-build:
     name: Build extension binaries
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.4.4
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5-variegata
     with:
-      duckdb_version: v1.4.4
-      ci_tools_version: v1.4.4
+      duckdb_version: v1.5.2
+      ci_tools_version: v1.5-variegata
       extension_name: agent_data
       extra_toolchains: rust
       exclude_archs: "wasm_mvp;wasm_eh;wasm_threads;linux_amd64_musl"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,9 +80,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
-version = "56.2.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e833808ff2d94ed40d9379848a950d995043c7fb3e81a30b383f4c6033821cc"
+checksum = "607e64bb911ee4f90483e044fe78f175989148c2892e659a2cd25429e782ec54"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -98,23 +98,23 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "56.2.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad08897b81588f60ba983e3ca39bda2b179bdd84dced378e7df81a5313802ef8"
+checksum = "e754319ed8a85d817fe7adf183227e0b5308b82790a737b426c1124626b48118"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
  "chrono",
- "num",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-array"
-version = "56.2.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8548ca7c070d8db9ce7aa43f37393e4bfcf3f2d3681df278490772fd1673d08d"
+checksum = "841321891f247aa86c6112c80d83d89cb36e0addd020fa2425085b8eb6c3f579"
 dependencies = [
  "ahash 0.8.12",
  "arrow-buffer",
@@ -122,30 +122,34 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
- "hashbrown 0.16.1",
- "num",
+ "hashbrown 0.17.0",
+ "num-complex",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-buffer"
-version = "56.2.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e003216336f70446457e280807a73899dd822feaf02087d31febca1363e2fccc"
+checksum = "f955dfb73fae000425f49c8226d2044dab60fb7ad4af1e24f961756354d996c9"
 dependencies = [
  "bytes",
  "half",
- "num",
+ "num-bigint",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-cast"
-version = "56.2.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919418a0681298d3a77d1a315f625916cb5678ad0d74b9c60108eb15fd083023"
+checksum = "ca5e686972523798f76bef355145bc1ae25a84c731e650268d31ab763c701663"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
+ "arrow-ord",
  "arrow-schema",
  "arrow-select",
  "atoi",
@@ -154,27 +158,28 @@ dependencies = [
  "comfy-table",
  "half",
  "lexical-core",
- "num",
+ "num-traits",
  "ryu",
 ]
 
 [[package]]
 name = "arrow-data"
-version = "56.2.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5c64fff1d142f833d78897a772f2e5b55b36cb3e6320376f0961ab0db7bd6d0"
+checksum = "db3b5846209775b6dc8056d77ff9a032b27043383dd5488abd0b663e265b9373"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
  "half",
- "num",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-ord"
-version = "56.2.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c8f82583eb4f8d84d4ee55fd1cb306720cddead7596edce95b50ee418edf66f"
+checksum = "efa70d9d6b1356f1fb9f1f651b84a725b7e0abb93f188cf7d31f14abfa2f2e6f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -185,9 +190,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "56.2.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d07ba24522229d9085031df6b94605e0f4b26e099fb7cdeec37abd941a73753"
+checksum = "faec88a945338192beffbbd4be0def70135422930caa244ac3cec0cd213b26b4"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -198,32 +203,32 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "56.2.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3aa9e59c611ebc291c28582077ef25c97f1975383f1479b12f3b9ffee2ffabe"
+checksum = "18aa020f6bc8e5201dcd2d4b7f98c68f8a410ef37128263243e6ff2a47a67d4f"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "arrow-select"
-version = "56.2.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c41dbbd1e97bfcaee4fcb30e29105fb2c75e4d82ae4de70b792a5d3f66b2e7a"
+checksum = "a657ab5132e9c8ca3b24eb15a823d0ced38017fe3930ff50167466b02e2d592c"
 dependencies = [
  "ahash 0.8.12",
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
- "num",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-string"
-version = "56.2.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f5183c150fbc619eede22b861ea7c0eebed8eaac0333eaa7f6da5205fd504d"
+checksum = "f6de2efbbd1a9f9780ceb8d1ff5d20421b35863b361e3386b4f571f1fc69fcb8"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -231,7 +236,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "memchr",
- "num",
+ "num-traits",
  "regex",
  "regex-syntax",
 ]
@@ -383,6 +388,8 @@ version = "7.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0d05af1e006a2407bedef5af410552494ce5be9090444dbbcb57258c1af3d56"
 dependencies = [
+ "crossterm 0.27.0",
+ "crossterm 0.28.1",
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "unicode-width",
@@ -421,6 +428,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "libc",
+ "parking_lot",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "parking_lot",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -509,12 +549,13 @@ dependencies = [
 
 [[package]]
 name = "duckdb"
-version = "1.4.4"
+version = "1.10502.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8685352ce688883098b61a361e86e87df66fc8c444f4a2411e884c16d5243a65"
+checksum = "0fdc796383b176dd5a45353fbb5e64583c0ee4da12cb62c9e510b785324b2488"
 dependencies = [
  "arrow",
  "cast",
+ "comfy-table",
  "duckdb-loadable-macros",
  "fallible-iterator",
  "fallible-streaming-iterator",
@@ -527,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "duckdb-loadable-macros"
-version = "0.1.14"
+version = "1.10502.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee30ae7df1ed1b07389651dc8ffa2f20862b3cadcf4334fe8461c739a2701ed6"
+checksum = "0c15036a8d19f31f53acef09ff910c96cff5fe9b5d8f59e6dc90e7b836e09b20"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -732,6 +773,12 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hashlink"
@@ -1087,9 +1134,9 @@ checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
 
 [[package]]
 name = "libduckdb-sys"
-version = "1.4.4"
+version = "1.10502.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78bacb8933586cee3b550c39b610d314f9b7a48701ac7a914a046165a4ad8da"
+checksum = "8d7401630ae2abcff642f7156294289e50f2d222e061c026ad797b01bf20c215"
 dependencies = [
  "flate2",
  "pkg-config",
@@ -1118,8 +1165,14 @@ checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.7.0",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1132,6 +1185,15 @@ name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -1173,20 +1235,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1215,28 +1263,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1257,6 +1283,29 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.18",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1485,6 +1534,15 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
@@ -1648,6 +1706,19 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
@@ -1655,7 +1726,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
 ]
 
@@ -1705,6 +1776,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "seahash"
@@ -2312,6 +2389,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2629,7 +2728,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ lto = true
 strip = true
 
 [dependencies]
-duckdb = { version = "=1.4.4", features = ["loadable-extension"] }
-libduckdb-sys = "=1.4.4"
+duckdb = { version = "=1.10502.0", features = ["loadable-extension"] }
+libduckdb-sys = "=1.10502.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ EXTENSION_NAME=agent_data
 USE_UNSTABLE_C_API=1
 
 # Target DuckDB version
-TARGET_DUCKDB_VERSION=v1.4.4
+TARGET_DUCKDB_VERSION=v1.5.2
 
 all: configure debug
 

--- a/README.md
+++ b/README.md
@@ -344,6 +344,19 @@ The compiled extension is at `build/debug/agent_data.duckdb_extension` (or `buil
 duckdb -unsigned -c "LOAD 'build/debug/agent_data.duckdb_extension'; FROM read_conversations();"
 ```
 
+## Community Extension Release Checklist
+
+When DuckDB publishes a new stable release, keep the community package aligned with
+the latest stable target:
+
+1. Update `duckdb` and `libduckdb-sys` in `Cargo.toml` to the crate version for the new DuckDB stable release, then refresh `Cargo.lock`.
+2. Update `TARGET_DUCKDB_VERSION` in `Makefile`.
+3. Update `.github/workflows/MainDistributionPipeline.yml` to the matching `duckdb_version`, `ci_tools_version`, and reusable `extension-ci-tools` workflow ref.
+4. Update example DuckDB constraints if the examples should validate against the new stable release.
+5. Run `make configure`, `make debug`, `make test`, `cargo test --locked`, and example smoke tests that load `AGENT_DATA_EXTENSION_PATH=build/debug/agent_data.duckdb_extension`.
+6. Update `duckdb/community-extensions` `extensions/agent_data/description.yml` so `repo.ref` points at the validated commit.
+7. After the upstream community-extension workflow deploys, verify `https://community-extensions.duckdb.org/<duckdb-version>/<platform>/agent_data.duckdb_extension.gz` returns 200 and `agent_data` appears on the DuckDB community extension list.
+
 ## License
 
 MIT — see [LICENSE](LICENSE).

--- a/examples/explorer/README.md
+++ b/examples/explorer/README.md
@@ -30,3 +30,11 @@ AGENT_DATA_CLAUDE_PATH=~/custom/.claude \
 AGENT_DATA_COPILOT_PATH=~/custom/.copilot \
 streamlit run app.py
 ```
+
+Use a locally built extension during development or before community binaries
+are available for a new DuckDB release:
+
+```bash
+AGENT_DATA_EXTENSION_PATH=../../build/debug/agent_data.duckdb_extension \
+streamlit run app.py
+```

--- a/examples/explorer/db.py
+++ b/examples/explorer/db.py
@@ -9,6 +9,23 @@ import streamlit as st
 logger = logging.getLogger(__name__)
 
 
+def _connect() -> duckdb.DuckDBPyConnection:
+    if os.environ.get("AGENT_DATA_EXTENSION_PATH"):
+        return duckdb.connect(config={"allow_unsigned_extensions": "true"})
+    return duckdb.connect()
+
+
+def _load_agent_data(con: duckdb.DuckDBPyConnection) -> None:
+    extension_path = os.environ.get("AGENT_DATA_EXTENSION_PATH")
+    if extension_path:
+        path = os.path.abspath(os.path.expanduser(extension_path)).replace("'", "''")
+        con.execute(f"LOAD '{path}'")
+        return
+
+    con.execute("INSTALL agent_data FROM community")
+    con.execute("LOAD agent_data")
+
+
 def get_connection() -> duckdb.DuckDBPyConnection:
     """Return a cached DuckDB connection with the agent_data extension loaded.
     
@@ -23,9 +40,8 @@ def get_connection() -> duckdb.DuckDBPyConnection:
             logger.warning("Stale DuckDB connection detected, reconnecting")
             st.cache_data.clear()
             st.session_state.pop("duckdb_con", None)
-    con = duckdb.connect()
-    con.execute("INSTALL agent_data FROM community")
-    con.execute("LOAD agent_data")
+    con = _connect()
+    _load_agent_data(con)
     st.session_state["duckdb_con"] = con
     return con
 

--- a/examples/explorer/pyproject.toml
+++ b/examples/explorer/pyproject.toml
@@ -6,6 +6,6 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "streamlit>=1.45",
-    "duckdb>=1.4",
+    "duckdb>=1.5.2",
     "pandas>=2.0",
 ]

--- a/examples/marimo/pyproject.toml
+++ b/examples/marimo/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "marimo>=0.19",
-    "duckdb>=1.4",
+    "duckdb>=1.5.2",
     "pandas>=2.0",
     "numpy>=2.0",
 ]

--- a/examples/tui/README.md
+++ b/examples/tui/README.md
@@ -28,6 +28,14 @@ Or with custom data paths:
 uv run python -m agent_chronicle --claude-path ~/.claude --copilot-path ~/.copilot
 ```
 
+Use a locally built extension during development or before community binaries
+are available for a new DuckDB release:
+
+```bash
+AGENT_DATA_EXTENSION_PATH=../../build/debug/agent_data.duckdb_extension \
+uv run python -m agent_chronicle
+```
+
 ## Development
 
 ```bash
@@ -54,8 +62,9 @@ make test      # Run tests (42 assertions)
 ## Architecture
 
 Built with Python Textual, reusing the data layer from the Streamlit explorer.
-The app loads the `agent_data` DuckDB community extension to read Claude and
-Copilot session data directly from their local storage directories.
+The app loads the `agent_data` DuckDB community extension, or the local path in
+`AGENT_DATA_EXTENSION_PATH`, to read Claude and Copilot session data directly
+from their local storage directories.
 
 Data loading is async (threaded workers with per-thread DuckDB connections)
 so the UI never blocks during startup or query execution.

--- a/examples/tui/agent_chronicle/db.py
+++ b/examples/tui/agent_chronicle/db.py
@@ -21,6 +21,24 @@ _connection: duckdb.DuckDBPyConnection | None = None
 _cache: dict[str, tuple[float, pd.DataFrame]] = {}
 
 
+def _connect() -> duckdb.DuckDBPyConnection:
+    if os.environ.get("AGENT_DATA_EXTENSION_PATH"):
+        return duckdb.connect(config={"allow_unsigned_extensions": "true"})
+    return duckdb.connect()
+
+
+def _load_agent_data(con: duckdb.DuckDBPyConnection) -> None:
+    extension_path = os.environ.get("AGENT_DATA_EXTENSION_PATH")
+    if extension_path:
+        path = Path(extension_path).expanduser().resolve()
+        escaped_path = path.as_posix().replace("'", "''")
+        con.execute(f"LOAD '{escaped_path}'")
+        return
+
+    con.execute("INSTALL agent_data FROM community")
+    con.execute("LOAD agent_data")
+
+
 def get_connection() -> duckdb.DuckDBPyConnection:
     """Return a DuckDB connection with agent_data extension loaded.
 
@@ -36,9 +54,8 @@ def get_connection() -> duckdb.DuckDBPyConnection:
             _connection = None
             _cache.clear()
 
-    con = duckdb.connect()
-    con.execute("INSTALL agent_data FROM community")
-    con.execute("LOAD agent_data")
+    con = _connect()
+    _load_agent_data(con)
     _connection = con
     return con
 
@@ -91,9 +108,9 @@ def _cached_query(key: str, sql: str) -> pd.DataFrame:
 
 def _threaded_query(sql: str) -> pd.DataFrame:
     """Execute a query in a fresh connection (thread-safe for workers)."""
-    con = duckdb.connect()
+    con = _connect()
     try:
-        con.execute("LOAD agent_data")
+        _load_agent_data(con)
         return con.execute(sql).df()
     except Exception as e:
         logger.error("Threaded query failed: %s", e)
@@ -104,10 +121,10 @@ def _threaded_query(sql: str) -> pd.DataFrame:
 
 def _run_queries_threaded(queries: dict[str, str]) -> dict[str, pd.DataFrame]:
     """Run multiple queries in a single thread-local connection."""
-    con = duckdb.connect()
+    con = _connect()
     results: dict[str, pd.DataFrame] = {}
     try:
-        con.execute("LOAD agent_data")
+        _load_agent_data(con)
         for key, sql in queries.items():
             try:
                 results[key] = con.execute(sql).df()

--- a/examples/tui/pyproject.toml
+++ b/examples/tui/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "textual>=1.0.0",
-    "duckdb>=1.4",
+    "duckdb>=1.5.2",
     "pandas>=2.0",
 ]
 

--- a/examples/tui/tests/conftest.py
+++ b/examples/tui/tests/conftest.py
@@ -8,6 +8,9 @@ from pathlib import Path
 TEST_DATA_DIR = Path(__file__).parent.parent / "test_data"
 CLAUDE_TEST_PATH = str(TEST_DATA_DIR / "claude")
 COPILOT_TEST_PATH = str(TEST_DATA_DIR / "copilot")
+LOCAL_EXTENSION_PATH = (
+    Path(__file__).resolve().parents[3] / "build" / "debug" / "agent_data.duckdb_extension"
+)
 
 
 @pytest.fixture(autouse=True)
@@ -15,6 +18,8 @@ def set_test_paths(monkeypatch):
     """Set environment variables to point at synthetic test data."""
     monkeypatch.setenv("AGENT_DATA_CLAUDE_PATH", CLAUDE_TEST_PATH)
     monkeypatch.setenv("AGENT_DATA_COPILOT_PATH", COPILOT_TEST_PATH)
+    if LOCAL_EXTENSION_PATH.exists():
+        monkeypatch.setenv("AGENT_DATA_EXTENSION_PATH", str(LOCAL_EXTENSION_PATH))
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- retargets the extension to DuckDB v1.5.2 / `duckdb` crate `1.10502.0`
- updates the community distribution workflow to `v1.5-variegata`
- adds `AGENT_DATA_EXTENSION_PATH` support so examples/tests can validate a freshly built local extension before community binaries are published

## Validation
- `cargo metadata --locked --format-version 1`
- `cargo check --locked`
- `make configure`
- `make debug`
- `make test`
- `cargo test --locked`
- `cd examples/tui && uv run pytest` (42 passed)
- manual DuckDB/Python smoke queries against `build/debug/agent_data.duckdb_extension` for Claude and Copilot synthetic data

## Listing baseline
- `agent_data` detail page returns 200
- latest-stable v1.5.2 community binary URLs currently return 404
- aggregate list membership is currently 0
- `INSTALL agent_data FROM community` currently fails on DuckDB 1.5.2 with HTTPException
