### PR TITLE
Automate DuckDB release maintenance

### DIFF
--- a/.github/workflows/duckdb-next-compat.yml
+++ b/.github/workflows/duckdb-next-compat.yml
@@ -1,0 +1,31 @@
+name: DuckDB Next Compatibility
+
+on:
+  schedule:
+    - cron: "43 7 * * 2"
+  workflow_dispatch:
+    inputs:
+      duckdb_version:
+        description: "DuckDB development target or release branch"
+        required: false
+        default: "main"
+        type: string
+      ci_tools_version:
+        description: "extension-ci-tools ref"
+        required: false
+        default: "main"
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  duckdb-next-build:
+    name: Build against DuckDB next
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
+    with:
+      duckdb_version: ${{ inputs.duckdb_version || 'main' }}
+      ci_tools_version: ${{ inputs.ci_tools_version || 'main' }}
+      extension_name: agent_data
+      extra_toolchains: rust
+      exclude_archs: "wasm_mvp;wasm_eh;wasm_threads;linux_amd64_musl"

--- a/.github/workflows/duckdb-release-monitor.yml
+++ b/.github/workflows/duckdb-release-monitor.yml
@@ -1,0 +1,88 @@
+name: DuckDB Release Monitor
+
+on:
+  schedule:
+    - cron: "19 7 * * 1"
+  workflow_dispatch:
+    inputs:
+      duckdb_version:
+        description: "DuckDB version to check/apply, e.g. v1.5.2. Defaults to latest release."
+        required: false
+        type: string
+  pull_request:
+    paths:
+      - duckdb-release.toml
+      - scripts/update_duckdb_release.py
+      - scripts/validate_duckdb_release.sh
+      - scripts/smoke_duckdb_release.py
+      - .github/workflows/duckdb-release-monitor.yml
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  release-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Check DuckDB release drift
+        id: drift
+        continue-on-error: true
+        run: |
+          args=(--check)
+          if [ -n "${{ inputs.duckdb_version || '' }}" ]; then
+            args+=(--duckdb-version "${{ inputs.duckdb_version }}")
+          fi
+          python3 scripts/update_duckdb_release.py "${args[@]}"
+
+      - name: Fail pull request on release drift
+        if: steps.drift.outcome == 'failure' && github.event_name == 'pull_request'
+        run: exit 1
+
+      - name: Apply DuckDB release update
+        if: steps.drift.outcome == 'failure' && github.event_name != 'pull_request'
+        run: |
+          args=(--apply)
+          if [ -n "${{ inputs.duckdb_version || '' }}" ]; then
+            args+=(--duckdb-version "${{ inputs.duckdb_version }}")
+          fi
+          python3 scripts/update_duckdb_release.py "${args[@]}"
+
+      - name: Validate generated update
+        if: steps.drift.outcome == 'failure' && github.event_name != 'pull_request'
+        run: scripts/validate_duckdb_release.sh
+
+      - name: Open release update PR
+        if: steps.drift.outcome == 'failure' && github.event_name != 'pull_request'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: automation/duckdb-release-update
+          title: "chore: update DuckDB release target"
+          body: |
+            Automated DuckDB release target update.
+
+            This PR was generated after `scripts/update_duckdb_release.py --apply`
+            and `scripts/validate_duckdb_release.sh` completed successfully.
+          commit-message: |
+            chore: update DuckDB release target
+
+            Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
+
+      - name: Open failure issue
+        if: failure() && steps.drift.outcome == 'failure' && github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          title="DuckDB release automation failed"
+          body="DuckDB release drift was detected, but the automated updater or validation failed in ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}."
+          existing="$(gh issue list --state open --label duckdb-release-drift --json number --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "$title" --body "$body" --label duckdb-release-drift
+          fi

--- a/README.md
+++ b/README.md
@@ -349,13 +349,61 @@ duckdb -unsigned -c "LOAD 'build/debug/agent_data.duckdb_extension'; FROM read_c
 When DuckDB publishes a new stable release, keep the community package aligned with
 the latest stable target:
 
-1. Update `duckdb` and `libduckdb-sys` in `Cargo.toml` to the crate version for the new DuckDB stable release, then refresh `Cargo.lock`.
-2. Update `TARGET_DUCKDB_VERSION` in `Makefile`.
-3. Update `.github/workflows/MainDistributionPipeline.yml` to the matching `duckdb_version`, `ci_tools_version`, and reusable `extension-ci-tools` workflow ref.
-4. Update example DuckDB constraints if the examples should validate against the new stable release.
-5. Run `make configure`, `make debug`, `make test`, `cargo test --locked`, and example smoke tests that load `AGENT_DATA_EXTENSION_PATH=build/debug/agent_data.duckdb_extension`.
-6. Update `duckdb/community-extensions` `extensions/agent_data/description.yml` so `repo.ref` points at the validated commit.
-7. After the upstream community-extension workflow deploys, verify `https://community-extensions.duckdb.org/<duckdb-version>/<platform>/agent_data.duckdb_extension.gz` returns 200 and `agent_data` appears on the DuckDB community extension list.
+1. Check whether the repo is still aligned with DuckDB latest stable:
+
+   ```bash
+   python3 scripts/update_duckdb_release.py --check
+   ```
+
+2. If a new stable release exists, update all local release surfaces:
+
+   ```bash
+   python3 scripts/update_duckdb_release.py --apply
+   ```
+
+   This updates `duckdb-release.toml`, `Cargo.toml`, `Cargo.lock`,
+   `Makefile`, `.github/workflows/MainDistributionPipeline.yml`, and
+   example DuckDB Python constraints.
+
+3. Run the full local validation entrypoint:
+
+   ```bash
+   scripts/validate_duckdb_release.sh
+   ```
+
+   This runs Rust/build/test checks and an exact-version DuckDB Python smoke
+   test that loads `build/debug/agent_data.duckdb_extension`.
+
+4. Update `duckdb/community-extensions` after the source commit is validated:
+
+   ```bash
+   scripts/prepare_community_extension_pr.py --open-pr
+   ```
+
+   Keep upstream `repo.ref` immutable. A commit SHA is preferred; an immutable
+   tag is also acceptable when maintainers intentionally release by tag. Do not
+   use `main` as the stable ref because community builds should be reproducible.
+
+5. After the upstream community-extension workflow deploys from a trusted
+   context, verify publication:
+
+   ```bash
+   uv run --with duckdb==$(python3 - <<'PY'
+import tomllib
+print(tomllib.load(open("duckdb-release.toml", "rb"))["duckdb"]["python_version"])
+PY
+) python scripts/verify_community_publication.py
+   ```
+
+   Pull-request deploys may build artifacts without publishing public binaries
+   when upstream secrets are unavailable.
+
+The scheduled `DuckDB Release Monitor` workflow checks for stable-release drift
+and opens a PR when the updater and validation pass. The `DuckDB Next
+Compatibility` workflow can be run on schedule or manually to test DuckDB
+`main`/next without publishing binaries. For DuckDB feature-freeze branches,
+use upstream `repo.ref_next` for pre-release validation, then update `repo.ref`
+after the stable source commit is merged.
 
 ## License
 

--- a/duckdb-release.toml
+++ b/duckdb-release.toml
@@ -1,0 +1,8 @@
+[duckdb]
+version = "v1.5.2"
+python_version = "1.5.2"
+crate_version = "1.10502.0"
+
+[ci]
+tools_ref = "v1.5-variegata"
+excluded_archs = "wasm_mvp;wasm_eh;wasm_threads;linux_amd64_musl"

--- a/scripts/community_extension_pr_body_template.md
+++ b/scripts/community_extension_pr_body_template.md
@@ -1,0 +1,23 @@
+## Summary
+- bumps `extensions/agent_data/description.yml` `repo.ref` to `{source_ref}`
+- the new source ref targets DuckDB `{duckdb_version}`, `duckdb`/`libduckdb-sys` crate `{crate_version}`, and `extension-ci-tools` `{ci_tools_ref}`
+- this should restore latest-stable community binaries so `agent_data` appears in the generated DuckDB community extension list again
+
+## Validation in source repo
+Source PR: {source_pr_url}
+
+Local validation performed there:
+- `cargo metadata --locked --format-version 1`
+- `cargo check --locked`
+- `make configure`
+- `make debug`
+- `make test`
+- `cargo test --locked`
+- `cd examples/tui && uv run pytest`
+- manual DuckDB/Python smoke queries against `build/debug/agent_data.duckdb_extension` for Claude and Copilot synthetic data
+
+## Current public baseline
+- `https://duckdb.org/community_extensions/extensions/agent_data.html` returns 200
+- `https://community-extensions.duckdb.org/{duckdb_version}/osx_arm64/agent_data.duckdb_extension.gz` returns 404 before trusted deployment
+- aggregate list membership for `agent_data` is currently 0 before trusted deployment
+- `INSTALL agent_data FROM community` currently fails on DuckDB {duckdb_python_version} before trusted deployment

--- a/scripts/prepare_community_extension_pr.py
+++ b/scripts/prepare_community_extension_pr.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Prepare a duckdb/community-extensions descriptor update for agent_data."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_COMMUNITY_REPO = ROOT / "tmp" / "community-extensions"
+DESCRIPTOR = Path("extensions/agent_data/description.yml")
+
+
+def run(command: list[str], cwd: Path = ROOT, check: bool = True) -> subprocess.CompletedProcess[str]:
+    print("+", " ".join(command), flush=True)
+    return subprocess.run(command, cwd=cwd, check=check, text=True, capture_output=False)
+
+
+def output(command: list[str], cwd: Path = ROOT) -> str:
+    return subprocess.check_output(command, cwd=cwd, text=True).strip()
+
+
+def ensure_clean_source() -> None:
+    status = output(["git", "status", "--porcelain"])
+    ignored = {"?? .github/workflows/roborev.yml"}
+    unexpected = [line for line in status.splitlines() if line and line not in ignored]
+    if unexpected:
+        raise RuntimeError("Source repository has uncommitted changes:\n" + "\n".join(unexpected))
+
+
+def update_descriptor(path: Path, source_ref: str) -> None:
+    lines = path.read_text().splitlines()
+    in_repo = False
+    changed = False
+    new_lines: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if line == "repo:":
+            in_repo = True
+            new_lines.append(line)
+            continue
+        if in_repo and line and not line.startswith(" "):
+            in_repo = False
+        if in_repo and stripped.startswith("ref:"):
+            indent = line[: len(line) - len(line.lstrip())]
+            new_lines.append(f"{indent}ref: {source_ref}")
+            changed = True
+        else:
+            new_lines.append(line)
+    if not changed:
+        raise RuntimeError(f"Could not find repo.ref in {path}")
+    path.write_text("\n".join(new_lines) + "\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--community-repo", type=Path, default=DEFAULT_COMMUNITY_REPO)
+    parser.add_argument("--source-ref", default=None, help="Source commit/tag to write; defaults to HEAD SHA")
+    parser.add_argument("--branch", default="bump-agent-data-duckdb-release")
+    parser.add_argument("--open-pr", action="store_true", help="Open a PR with gh after committing")
+    parser.add_argument("--skip-clean-check", action="store_true")
+    args = parser.parse_args()
+
+    if not args.skip_clean_check:
+        ensure_clean_source()
+
+    source_ref = args.source_ref or output(["git", "rev-parse", "HEAD"])
+    community_repo = args.community_repo.resolve()
+    if not community_repo.exists():
+        run(["git", "clone", "https://github.com/duckdb/community-extensions.git", str(community_repo)])
+
+    descriptor = community_repo / DESCRIPTOR
+    if not descriptor.exists():
+        raise RuntimeError(f"Missing descriptor: {descriptor}")
+
+    run(["git", "fetch", "origin", "main"], cwd=community_repo)
+    run(["git", "checkout", "-B", args.branch, "origin/main"], cwd=community_repo)
+    update_descriptor(descriptor, source_ref)
+    run(["git", "add", str(DESCRIPTOR)], cwd=community_repo)
+    diff = output(["git", "diff", "--cached", "--stat"], cwd=community_repo)
+    if not diff:
+        print("Descriptor already points at requested ref.")
+        return 0
+    run(["git", "commit", "-m", f"agent_data: update source ref to {source_ref[:12]}"], cwd=community_repo)
+
+    if args.open_pr:
+        run(["git", "push", "-u", "origin", args.branch], cwd=community_repo)
+        run(
+            [
+                "gh",
+                "pr",
+                "create",
+                "--repo",
+                "duckdb/community-extensions",
+                "--title",
+                "agent_data: update source ref",
+                "--body",
+                f"Updates `agent_data` to validated source ref `{source_ref}`.",
+            ],
+            cwd=community_repo,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/scripts/prepare_community_extension_pr.py
+++ b/scripts/prepare_community_extension_pr.py
@@ -6,12 +6,14 @@ from __future__ import annotations
 import argparse
 import subprocess
 import sys
+import tomllib
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_COMMUNITY_REPO = ROOT / "tmp" / "community-extensions"
 DESCRIPTOR = Path("extensions/agent_data/description.yml")
+DEFAULT_BODY_TEMPLATE = ROOT / "scripts" / "community_extension_pr_body_template.md"
 
 
 def run(command: list[str], cwd: Path = ROOT, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -21,6 +23,13 @@ def run(command: list[str], cwd: Path = ROOT, check: bool = True) -> subprocess.
 
 def output(command: list[str], cwd: Path = ROOT) -> str:
     return subprocess.check_output(command, cwd=cwd, text=True).strip()
+
+
+def optional_output(command: list[str], cwd: Path = ROOT) -> str | None:
+    try:
+        return output(command, cwd=cwd)
+    except subprocess.CalledProcessError:
+        return None
 
 
 def ensure_clean_source() -> None:
@@ -55,19 +64,52 @@ def update_descriptor(path: Path, source_ref: str) -> None:
     path.write_text("\n".join(new_lines) + "\n")
 
 
+def release_metadata() -> dict[str, str]:
+    with open(ROOT / "duckdb-release.toml", "rb") as handle:
+        data = tomllib.load(handle)
+    return {
+        "duckdb_version": data["duckdb"]["version"],
+        "duckdb_python_version": data["duckdb"]["python_version"],
+        "crate_version": data["duckdb"]["crate_version"],
+        "ci_tools_ref": data["ci"]["tools_ref"],
+    }
+
+
+def source_pr_url(explicit_url: str | None) -> str:
+    if explicit_url:
+        return explicit_url
+    detected = optional_output(["gh", "pr", "view", "--json", "url", "--jq", ".url"])
+    return detected or "TODO: add source PR URL"
+
+
+def render_body(template: Path, source_ref: str, explicit_source_pr_url: str | None) -> str:
+    values = release_metadata()
+    values["source_ref"] = source_ref
+    values["source_pr_url"] = source_pr_url(explicit_source_pr_url)
+    return template.read_text().format(**values)
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--community-repo", type=Path, default=DEFAULT_COMMUNITY_REPO)
     parser.add_argument("--source-ref", default=None, help="Source commit/tag to write; defaults to HEAD SHA")
     parser.add_argument("--branch", default="bump-agent-data-duckdb-release")
+    parser.add_argument("--body-template", type=Path, default=DEFAULT_BODY_TEMPLATE)
+    parser.add_argument("--source-pr-url", help="Source repository PR URL to include in the upstream PR body")
+    parser.add_argument("--print-body", action="store_true", help="Render the upstream PR body and exit")
     parser.add_argument("--open-pr", action="store_true", help="Open a PR with gh after committing")
     parser.add_argument("--skip-clean-check", action="store_true")
     args = parser.parse_args()
 
+    source_ref = args.source_ref or output(["git", "rev-parse", "HEAD"])
+    body = render_body(args.body_template, source_ref, args.source_pr_url)
+    if args.print_body:
+        print(body)
+        return 0
+
     if not args.skip_clean_check:
         ensure_clean_source()
 
-    source_ref = args.source_ref or output(["git", "rev-parse", "HEAD"])
     community_repo = args.community_repo.resolve()
     if not community_repo.exists():
         run(["git", "clone", "https://github.com/duckdb/community-extensions.git", str(community_repo)])
@@ -98,7 +140,7 @@ def main() -> int:
                 "--title",
                 "agent_data: update source ref",
                 "--body",
-                f"Updates `agent_data` to validated source ref `{source_ref}`.",
+                body,
             ],
             cwd=community_repo,
         )

--- a/scripts/smoke_duckdb_release.py
+++ b/scripts/smoke_duckdb_release.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Manual smoke test for the locally built agent_data extension."""
+
+from __future__ import annotations
+
+import os
+import sys
+import tomllib
+from pathlib import Path
+
+import duckdb
+
+
+ROOT = Path(__file__).resolve().parents[1]
+METADATA = ROOT / "duckdb-release.toml"
+
+
+def metadata_duckdb_version() -> str:
+    data = tomllib.loads(METADATA.read_text())
+    return data["duckdb"]["python_version"]
+
+
+def main() -> int:
+    expected_duckdb = metadata_duckdb_version()
+    if duckdb.__version__ != expected_duckdb:
+        print(f"Expected DuckDB Python {expected_duckdb}, got {duckdb.__version__}", file=sys.stderr)
+        return 1
+
+    extension = Path(os.environ.get("AGENT_DATA_EXTENSION_PATH", ROOT / "build/debug/agent_data.duckdb_extension"))
+    extension = extension.expanduser().resolve()
+    if not extension.exists():
+        print(f"Missing local extension: {extension}", file=sys.stderr)
+        return 1
+
+    con = duckdb.connect(config={"allow_unsigned_extensions": "true"})
+    escaped_extension = extension.as_posix().replace("'", "''")
+    con.execute(f"LOAD '{escaped_extension}'")
+
+    checks = {
+        "claude_conversations": "SELECT count(*) FROM read_conversations(path='test/data_claude', source='claude')",
+        "copilot_conversations": "SELECT count(*) FROM read_conversations(path='test/data_copilot', source='copilot')",
+        "claude_todos": "SELECT count(*) FROM read_todos(path='test/data_claude', source='claude')",
+        "copilot_todos": "SELECT count(*) FROM read_todos(path='test/data_copilot', source='copilot')",
+        "claude_plans": "SELECT count(*) FROM read_plans(path='test/data_claude', source='claude')",
+        "copilot_plans": "SELECT count(*) FROM read_plans(path='test/data_copilot', source='copilot')",
+        "claude_history": "SELECT count(*) FROM read_history(path='test/data_claude', source='claude')",
+        "copilot_history": "SELECT count(*) FROM read_history(path='test/data_copilot', source='copilot')",
+        "claude_stats": "SELECT count(*) FROM read_stats(path='test/data_claude', source='claude')",
+        "copilot_stats": "SELECT count(*) FROM read_stats(path='test/data_copilot', source='copilot')",
+        "autodetect_claude": "SELECT count(*) FROM read_conversations(path='test/data_claude')",
+        "autodetect_copilot": "SELECT count(*) FROM read_conversations(path='test/data_copilot')",
+    }
+
+    results: dict[str, int] = {}
+    for name, sql in checks.items():
+        count = con.execute(sql).fetchone()[0]
+        results[name] = count
+        print(f"{name}={count}")
+
+    expected_positive = [name for name in checks if name != "copilot_stats"]
+    missing = [name for name in expected_positive if results[name] <= 0]
+    if missing:
+        print(f"Expected positive row counts for: {', '.join(missing)}", file=sys.stderr)
+        return 1
+    if results["copilot_stats"] != 0:
+        print("Expected copilot_stats=0 because stats are Claude-only", file=sys.stderr)
+        return 1
+
+    print("manual_smoke=pass")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/update_duckdb_release.py
+++ b/scripts/update_duckdb_release.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""Check or update DuckDB release targets across the repository."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tomllib
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+METADATA = ROOT / "duckdb-release.toml"
+EXTENSION_WORKFLOW = ROOT / ".github" / "workflows" / "MainDistributionPipeline.yml"
+EXAMPLE_PYPROJECTS = [
+    ROOT / "examples" / "explorer" / "pyproject.toml",
+    ROOT / "examples" / "marimo" / "pyproject.toml",
+    ROOT / "examples" / "tui" / "pyproject.toml",
+]
+
+
+@dataclass(frozen=True)
+class ReleaseTarget:
+    duckdb_version: str
+    python_version: str
+    crate_version: str
+    ci_tools_ref: str
+    excluded_archs: str
+
+
+def http_json(url: str) -> object:
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "agent-data-duckdb-release-updater",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return json.load(response)
+
+
+def latest_duckdb_release() -> str:
+    data = http_json("https://api.github.com/repos/duckdb/duckdb/releases/latest")
+    tag = data.get("tag_name") if isinstance(data, dict) else None
+    if not isinstance(tag, str) or not re.fullmatch(r"v\d+\.\d+\.\d+", tag):
+        raise RuntimeError(f"Could not determine latest DuckDB release from GitHub: {tag!r}")
+    return tag
+
+
+def crate_versions(crate: str) -> set[str]:
+    data = http_json(f"https://crates.io/api/v1/crates/{crate}")
+    versions = data.get("versions") if isinstance(data, dict) else None
+    if not isinstance(versions, list):
+        raise RuntimeError(f"Could not read versions for crate {crate}")
+    return {item["num"] for item in versions if isinstance(item, dict) and "num" in item}
+
+
+def duckdb_version_parts(duckdb_version: str) -> tuple[int, int, int]:
+    match = re.fullmatch(r"v(\d+)\.(\d+)\.(\d+)", duckdb_version)
+    if not match:
+        raise ValueError(f"DuckDB version must look like vX.Y.Z, got {duckdb_version!r}")
+    return tuple(int(part) for part in match.groups())
+
+
+def candidate_crate_versions(duckdb_version: str) -> list[str]:
+    major, minor, patch = duckdb_version_parts(duckdb_version)
+    normal = f"{major}.{minor}.{patch}"
+    # duckdb-rs uses 1.10XYZ.0 for DuckDB 1.5+ releases.
+    encoded = f"{major}.{10000 + (minor * 100) + patch}.0"
+    return list(dict.fromkeys([encoded, normal]))
+
+
+def resolve_crate_version(duckdb_version: str) -> str:
+    duckdb_versions = crate_versions("duckdb")
+    sys_versions = crate_versions("libduckdb-sys")
+    for candidate in candidate_crate_versions(duckdb_version):
+        if candidate in duckdb_versions and candidate in sys_versions:
+            return candidate
+    candidates = ", ".join(candidate_crate_versions(duckdb_version))
+    raise RuntimeError(
+        "Could not resolve matching duckdb/libduckdb-sys crates for "
+        f"{duckdb_version}; tried {candidates}"
+    )
+
+
+def extension_ci_heads() -> list[str]:
+    data = http_json("https://api.github.com/repos/duckdb/extension-ci-tools/git/matching-refs/heads/")
+    if not isinstance(data, list):
+        raise RuntimeError("Could not read extension-ci-tools branch refs")
+    refs: list[str] = []
+    for item in data:
+        ref = item.get("ref") if isinstance(item, dict) else None
+        if isinstance(ref, str) and ref.startswith("refs/heads/"):
+            refs.append(ref.removeprefix("refs/heads/"))
+    return refs
+
+
+def resolve_ci_tools_ref(duckdb_version: str) -> str:
+    major, minor, _ = duckdb_version_parts(duckdb_version)
+    heads = extension_ci_heads()
+    minor_prefix = f"v{major}.{minor}-"
+    codename_heads = sorted(head for head in heads if head.startswith(minor_prefix))
+    if codename_heads:
+        return codename_heads[-1]
+    exact_heads = [duckdb_version, f"v{major}.{minor}.0", f"v{major}.{minor}"]
+    for head in exact_heads:
+        if head in heads:
+            return head
+    raise RuntimeError(f"Could not resolve extension-ci-tools ref for {duckdb_version}")
+
+
+def read_metadata() -> ReleaseTarget:
+    data = tomllib.loads(METADATA.read_text())
+    return ReleaseTarget(
+        duckdb_version=data["duckdb"]["version"],
+        python_version=data["duckdb"]["python_version"],
+        crate_version=data["duckdb"]["crate_version"],
+        ci_tools_ref=data["ci"]["tools_ref"],
+        excluded_archs=data["ci"]["excluded_archs"],
+    )
+
+
+def write_metadata(target: ReleaseTarget) -> None:
+    METADATA.write_text(
+        "\n".join(
+            [
+                "[duckdb]",
+                f'version = "{target.duckdb_version}"',
+                f'python_version = "{target.python_version}"',
+                f'crate_version = "{target.crate_version}"',
+                "",
+                "[ci]",
+                f'tools_ref = "{target.ci_tools_ref}"',
+                f'excluded_archs = "{target.excluded_archs}"',
+                "",
+            ]
+        )
+    )
+
+
+def replace(path: Path, pattern: str, replacement: str) -> None:
+    text = path.read_text()
+    new_text, count = re.subn(pattern, replacement, text, flags=re.MULTILINE)
+    if count == 0:
+        raise RuntimeError(f"No match for {pattern!r} in {path}")
+    path.write_text(new_text)
+
+
+def apply_target(target: ReleaseTarget, update_lockfile: bool) -> None:
+    write_metadata(target)
+    replace(
+        ROOT / "Cargo.toml",
+        r'duckdb = \{ version = "=[^"]+", features = \["loadable-extension"\] \}',
+        f'duckdb = {{ version = "={target.crate_version}", features = ["loadable-extension"] }}',
+    )
+    replace(
+        ROOT / "Cargo.toml",
+        r'libduckdb-sys = "=[^"]+"',
+        f'libduckdb-sys = "={target.crate_version}"',
+    )
+    replace(
+        ROOT / "Makefile",
+        r"^TARGET_DUCKDB_VERSION=.*$",
+        f"TARGET_DUCKDB_VERSION={target.duckdb_version}",
+    )
+    replace(
+        EXTENSION_WORKFLOW,
+        r"uses: duckdb/extension-ci-tools/\.github/workflows/_extension_distribution\.yml@.+",
+        f"uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@{target.ci_tools_ref}",
+    )
+    replace(
+        EXTENSION_WORKFLOW,
+        r"duckdb_version: .+",
+        f"duckdb_version: {target.duckdb_version}",
+    )
+    replace(
+        EXTENSION_WORKFLOW,
+        r"ci_tools_version: .+",
+        f"ci_tools_version: {target.ci_tools_ref}",
+    )
+    replace(
+        EXTENSION_WORKFLOW,
+        r'exclude_archs: ".+"',
+        f'exclude_archs: "{target.excluded_archs}"',
+    )
+    for pyproject in EXAMPLE_PYPROJECTS:
+        replace(pyproject, r'duckdb>=\d+\.\d+\.\d+', f"duckdb>={target.python_version}")
+    if update_lockfile:
+        run(["cargo", "update", "-p", "duckdb", "--precise", target.crate_version])
+        run(["cargo", "update", "-p", "libduckdb-sys", "--precise", target.crate_version])
+
+
+def run(command: list[str]) -> None:
+    print("+", " ".join(command), flush=True)
+    subprocess.run(command, cwd=ROOT, check=True)
+
+
+def parse_current_files() -> dict[str, str]:
+    cargo = (ROOT / "Cargo.toml").read_text()
+    makefile = (ROOT / "Makefile").read_text()
+    workflow = EXTENSION_WORKFLOW.read_text()
+    current = {
+        "metadata.duckdb_version": read_metadata().duckdb_version,
+        "metadata.python_version": read_metadata().python_version,
+        "metadata.crate_version": read_metadata().crate_version,
+        "metadata.ci_tools_ref": read_metadata().ci_tools_ref,
+        "metadata.excluded_archs": read_metadata().excluded_archs,
+        "cargo.duckdb": match_one(r'duckdb = \{ version = "=([^"]+)"', cargo, "Cargo.toml duckdb"),
+        "cargo.libduckdb-sys": match_one(r'libduckdb-sys = "=([^"]+)"', cargo, "Cargo.toml libduckdb-sys"),
+        "makefile.duckdb_version": match_one(r"^TARGET_DUCKDB_VERSION=(.+)$", makefile, "Makefile"),
+        "workflow.ci_tools_ref": match_one(
+            r"uses: duckdb/extension-ci-tools/\.github/workflows/_extension_distribution\.yml@(.+)",
+            workflow,
+            "workflow reusable ref",
+        ),
+        "workflow.duckdb_version": match_one(r"duckdb_version: (.+)", workflow, "workflow duckdb_version"),
+        "workflow.ci_tools_version": match_one(r"ci_tools_version: (.+)", workflow, "workflow ci_tools_version"),
+        "workflow.excluded_archs": match_one(r'exclude_archs: "(.+)"', workflow, "workflow exclude_archs"),
+    }
+    for pyproject in EXAMPLE_PYPROJECTS:
+        current[f"{pyproject.relative_to(ROOT)}.duckdb"] = match_one(
+            r"duckdb>=(\d+\.\d+\.\d+)", pyproject.read_text(), str(pyproject)
+        )
+    return current
+
+
+def match_one(pattern: str, text: str, label: str) -> str:
+    match = re.search(pattern, text, flags=re.MULTILINE)
+    if not match:
+        raise RuntimeError(f"Could not parse {label}")
+    return match.group(1).strip()
+
+
+def expected_values(target: ReleaseTarget) -> dict[str, str]:
+    expected = {
+        "metadata.duckdb_version": target.duckdb_version,
+        "metadata.python_version": target.python_version,
+        "metadata.crate_version": target.crate_version,
+        "metadata.ci_tools_ref": target.ci_tools_ref,
+        "metadata.excluded_archs": target.excluded_archs,
+        "cargo.duckdb": target.crate_version,
+        "cargo.libduckdb-sys": target.crate_version,
+        "makefile.duckdb_version": target.duckdb_version,
+        "workflow.ci_tools_ref": target.ci_tools_ref,
+        "workflow.duckdb_version": target.duckdb_version,
+        "workflow.ci_tools_version": target.ci_tools_ref,
+        "workflow.excluded_archs": target.excluded_archs,
+    }
+    for pyproject in EXAMPLE_PYPROJECTS:
+        expected[f"{pyproject.relative_to(ROOT)}.duckdb"] = target.python_version
+    return expected
+
+
+def check_target(target: ReleaseTarget) -> list[str]:
+    current = parse_current_files()
+    expected = expected_values(target)
+    mismatches: list[str] = []
+    for key, expected_value in expected.items():
+        current_value = current.get(key)
+        if current_value != expected_value:
+            mismatches.append(f"{key}: current={current_value!r} expected={expected_value!r}")
+    return mismatches
+
+
+def resolve_target(duckdb_version: str | None) -> ReleaseTarget:
+    version = duckdb_version or latest_duckdb_release()
+    bare_version = version.removeprefix("v")
+    return ReleaseTarget(
+        duckdb_version=version,
+        python_version=bare_version,
+        crate_version=resolve_crate_version(version),
+        ci_tools_ref=resolve_ci_tools_ref(version),
+        excluded_archs=read_metadata().excluded_archs if METADATA.exists() else "wasm_mvp;wasm_eh;wasm_threads;linux_amd64_musl",
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--duckdb-version", help="DuckDB version to check/apply, e.g. v1.5.2")
+    parser.add_argument("--check", action="store_true", help="Check configured versions for drift")
+    parser.add_argument("--apply", action="store_true", help="Apply the resolved version to local files")
+    parser.add_argument(
+        "--no-lockfile-update",
+        action="store_true",
+        help="Do not run cargo update after editing Cargo.toml",
+    )
+    args = parser.parse_args()
+    if args.check == args.apply:
+        parser.error("choose exactly one of --check or --apply")
+
+    target = resolve_target(args.duckdb_version)
+    if args.apply:
+        apply_target(target, update_lockfile=not args.no_lockfile_update)
+
+    mismatches = check_target(target)
+    if mismatches:
+        print(f"DuckDB release drift detected for {target.duckdb_version}:")
+        for mismatch in mismatches:
+            print(f"- {mismatch}")
+        return 1
+
+    print(
+        "DuckDB release configuration is current: "
+        f"{target.duckdb_version} / crate {target.crate_version} / CI {target.ci_tools_ref}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_duckdb_release.sh
+++ b/scripts/validate_duckdb_release.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+mkdir -p tmp
+
+python3 scripts/update_duckdb_release.py --check
+
+cargo metadata --locked > tmp/cargo-metadata.json
+cargo check --locked
+make configure
+make debug
+make test
+cargo test --locked
+
+if [ -f examples/tui/pyproject.toml ]; then
+  (
+    cd examples/tui
+    AGENT_DATA_EXTENSION_PATH="$ROOT/build/debug/agent_data.duckdb_extension" uv run pytest
+  )
+fi
+
+DUCKDB_PYTHON_VERSION="$(
+  python3 - <<'PY'
+import tomllib
+with open("duckdb-release.toml", "rb") as f:
+    print(tomllib.load(f)["duckdb"]["python_version"])
+PY
+)"
+
+AGENT_DATA_EXTENSION_PATH="$ROOT/build/debug/agent_data.duckdb_extension" \
+  uv run --with "duckdb==${DUCKDB_PYTHON_VERSION}" python scripts/smoke_duckdb_release.py \
+  | tee tmp/manual-duckdb-${DUCKDB_PYTHON_VERSION}-smoke.log

--- a/scripts/verify_community_publication.py
+++ b/scripts/verify_community_publication.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Verify agent_data is publicly published for the configured DuckDB release."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tomllib
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_PLATFORMS = ["osx_arm64", "osx_amd64", "linux_amd64", "linux_arm64", "windows_amd64"]
+
+
+def metadata_version() -> str:
+    data = tomllib.loads((ROOT / "duckdb-release.toml").read_text())
+    return data["duckdb"]["version"]
+
+
+def status_code(url: str) -> int:
+    request = urllib.request.Request(url, method="HEAD", headers={"User-Agent": "agent-data-publication-verifier"})
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return response.status
+    except urllib.error.HTTPError as exc:
+        return exc.code
+
+
+def fetch_text(url: str) -> str:
+    request = urllib.request.Request(url, headers={"User-Agent": "agent-data-publication-verifier"})
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return response.read().decode("utf-8", errors="replace")
+
+
+def verify_install() -> None:
+    import duckdb
+
+    con = duckdb.connect()
+    con.execute("INSTALL agent_data FROM community")
+    con.execute("LOAD agent_data")
+    con.execute("SELECT count(*) FROM duckdb_extensions() WHERE extension_name = 'agent_data'").fetchone()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--duckdb-version", default=metadata_version())
+    parser.add_argument("--platform", action="append", dest="platforms")
+    parser.add_argument("--skip-install", action="store_true")
+    args = parser.parse_args()
+
+    platforms = args.platforms or DEFAULT_PLATFORMS
+    failures: list[str] = []
+    for platform in platforms:
+        url = (
+            "https://community-extensions.duckdb.org/"
+            f"{args.duckdb_version}/{platform}/agent_data.duckdb_extension.gz"
+        )
+        code = status_code(url)
+        print(f"{platform} {code} {url}")
+        if code != 200:
+            failures.append(f"{platform} binary returned {code}")
+
+    list_url = "https://duckdb.org/community_extensions/list_of_extensions"
+    list_body = fetch_text(list_url)
+    in_list = "agent_data" in list_body
+    print(f"aggregate_list_contains_agent_data={in_list}")
+    if not in_list:
+        failures.append("aggregate community extension list does not include agent_data")
+
+    if not args.skip_install:
+        try:
+            verify_install()
+            print("community_install=pass")
+        except Exception as exc:
+            failures.append(f"INSTALL/LOAD failed: {exc}")
+            print(f"community_install=fail: {exc}")
+
+    if failures:
+        print("Publication verification failed. If this is a pull-request build, confirm whether upstream deploy logs say 'No AWS key found, skipping..'.", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds end-to-end automation to keep the agent_data DuckDB extension aligned with future DuckDB releases.

- centralizes DuckDB release metadata in duckdb-release.toml
- adds a drift checker/updater for Cargo, Makefile, CI, and example constraints
- adds deterministic local release validation and exact-version DuckDB smoke testing
- adds scheduled release-monitor and next-compatibility workflows
- adds helpers for upstream community descriptor PRs and public publication verification
- documents immutable repo.ref policy and repo.ref_next usage

## Validation

- scripts/validate_duckdb_release.sh
- python3 scripts/update_duckdb_release.py --apply --duckdb-version v1.5.2
- python3 scripts/update_duckdb_release.py --check
- uv run --with duckdb==1.5.2 python scripts/smoke_duckdb_release.py
