### PR TITLE
Support DuckDB 1.5.3 release

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build extension binaries
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5-variegata
     with:
-      duckdb_version: v1.5.2
+      duckdb_version: v1.5.3
       ci_tools_version: v1.5-variegata
       extension_name: agent_data
       extra_toolchains: rust

--- a/.github/workflows/duckdb-release-monitor.yml
+++ b/.github/workflows/duckdb-release-monitor.yml
@@ -32,20 +32,34 @@ jobs:
 
       - name: Check DuckDB release drift
         id: drift
-        continue-on-error: true
         run: |
           args=(--check)
           if [ -n "${{ inputs.duckdb_version || '' }}" ]; then
             args+=(--duckdb-version "${{ inputs.duckdb_version }}")
           fi
+          set +e
           python3 scripts/update_duckdb_release.py "${args[@]}"
+          rc=$?
+          set -e
+          echo "exit_code=$rc" >> "$GITHUB_OUTPUT"
+          case "$rc" in
+            0)
+              echo "status=current" >> "$GITHUB_OUTPUT"
+              ;;
+            10)
+              echo "status=drift" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "status=error" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
 
-      - name: Fail pull request on release drift
-        if: steps.drift.outcome == 'failure' && github.event_name == 'pull_request'
+      - name: Fail pull request on release drift or check error
+        if: steps.drift.outputs.status != 'current' && github.event_name == 'pull_request'
         run: exit 1
 
       - name: Apply DuckDB release update
-        if: steps.drift.outcome == 'failure' && github.event_name != 'pull_request'
+        if: steps.drift.outputs.status == 'drift' && github.event_name != 'pull_request'
         run: |
           args=(--apply)
           if [ -n "${{ inputs.duckdb_version || '' }}" ]; then
@@ -54,11 +68,11 @@ jobs:
           python3 scripts/update_duckdb_release.py "${args[@]}"
 
       - name: Validate generated update
-        if: steps.drift.outcome == 'failure' && github.event_name != 'pull_request'
+        if: steps.drift.outputs.status == 'drift' && github.event_name != 'pull_request'
         run: scripts/validate_duckdb_release.sh
 
       - name: Open release update PR
-        if: steps.drift.outcome == 'failure' && github.event_name != 'pull_request'
+        if: steps.drift.outputs.status == 'drift' && github.event_name != 'pull_request'
         uses: peter-evans/create-pull-request@v7
         with:
           branch: automation/duckdb-release-update
@@ -74,15 +88,32 @@ jobs:
             Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
 
       - name: Open failure issue
-        if: failure() && steps.drift.outcome == 'failure' && github.event_name != 'pull_request'
+        if: (failure() || steps.drift.outputs.status == 'error') && github.event_name != 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           title="DuckDB release automation failed"
           body="DuckDB release drift was detected, but the automated updater or validation failed in ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}."
-          existing="$(gh issue list --state open --label duckdb-release-drift --json number --jq '.[0].number // empty')"
+          {
+            echo "## DuckDB release automation failed"
+            echo ""
+            echo "- Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            echo "- Drift check status: ${{ steps.drift.outputs.status }}"
+            echo "- Drift check exit code: ${{ steps.drift.outputs.exit_code }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+          label_args=()
+          if gh label create duckdb-release-drift --color BFDADC --description "DuckDB release drift automation" --force; then
+            label_args=(--label duckdb-release-drift)
+            existing="$(gh issue list --state open "${label_args[@]}" --json number --jq '.[0].number // empty')"
+          else
+            echo "Could not create duckdb-release-drift label; creating issue without label." >> "$GITHUB_STEP_SUMMARY"
+            existing="$(gh issue list --state open --search "$title in:title" --json number --jq '.[0].number // empty')"
+          fi
           if [ -n "$existing" ]; then
             gh issue comment "$existing" --body "$body"
           else
-            gh issue create --title "$title" --body "$body" --label duckdb-release-drift
+            gh issue create --title "$title" --body "$body" "${label_args[@]}"
+          fi
+          if [ "${{ steps.drift.outputs.status }}" = "error" ]; then
+            exit 1
           fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "duckdb"
-version = "1.10502.0"
+version = "1.10503.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdc796383b176dd5a45353fbb5e64583c0ee4da12cb62c9e510b785324b2488"
+checksum = "0cb42b21e3be42ef14acda15ce8dc99c125ce5376b87c8016a432cf14ae65de1"
 dependencies = [
  "arrow",
  "cast",
@@ -568,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "duckdb-loadable-macros"
-version = "1.10502.0"
+version = "1.10503.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c15036a8d19f31f53acef09ff910c96cff5fe9b5d8f59e6dc90e7b836e09b20"
+checksum = "a84e99ae9908b599625b82a8e557acef31bd153cefd84eb9cf7b3fc28975ca2a"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1134,9 +1134,9 @@ checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
 
 [[package]]
 name = "libduckdb-sys"
-version = "1.10502.0"
+version = "1.10503.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d7401630ae2abcff642f7156294289e50f2d222e061c026ad797b01bf20c215"
+checksum = "c9a4389c243e7afa0fbc8d8471031335ddc8a2dac4534f3290c9c2ba3edabab5"
 dependencies = [
  "flate2",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ lto = true
 strip = true
 
 [dependencies]
-duckdb = { version = "=1.10502.0", features = ["loadable-extension"] }
-libduckdb-sys = "=1.10502.0"
+duckdb = { version = "=1.10503.1", features = ["loadable-extension"] }
+libduckdb-sys = "=1.10503.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ EXTENSION_NAME=agent_data
 USE_UNSTABLE_C_API=1
 
 # Target DuckDB version
-TARGET_DUCKDB_VERSION=v1.5.2
+TARGET_DUCKDB_VERSION=v1.5.3
 
 all: configure debug
 

--- a/duckdb-release.toml
+++ b/duckdb-release.toml
@@ -1,7 +1,7 @@
 [duckdb]
-version = "v1.5.2"
-python_version = "1.5.2"
-crate_version = "1.10502.0"
+version = "v1.5.3"
+python_version = "1.5.3"
+crate_version = "1.10503.1"
 
 [ci]
 tools_ref = "v1.5-variegata"

--- a/examples/explorer/pyproject.toml
+++ b/examples/explorer/pyproject.toml
@@ -6,6 +6,6 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "streamlit>=1.45",
-    "duckdb>=1.5.2",
+    "duckdb>=1.5.3",
     "pandas>=2.0",
 ]

--- a/examples/marimo/pyproject.toml
+++ b/examples/marimo/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "marimo>=0.19",
-    "duckdb>=1.5.2",
+    "duckdb>=1.5.3",
     "pandas>=2.0",
     "numpy>=2.0",
 ]

--- a/examples/tui/pyproject.toml
+++ b/examples/tui/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "textual>=1.0.0",
-    "duckdb>=1.5.2",
+    "duckdb>=1.5.3",
     "pandas>=2.0",
 ]
 

--- a/scripts/update_duckdb_release.py
+++ b/scripts/update_duckdb_release.py
@@ -17,6 +17,9 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 METADATA = ROOT / "duckdb-release.toml"
 EXTENSION_WORKFLOW = ROOT / ".github" / "workflows" / "MainDistributionPipeline.yml"
+EXIT_CURRENT = 0
+EXIT_ERROR = 1
+EXIT_DRIFT = 10
 EXAMPLE_PYPROJECTS = [
     ROOT / "examples" / "explorer" / "pyproject.toml",
     ROOT / "examples" / "marimo" / "pyproject.toml",
@@ -76,9 +79,27 @@ def candidate_crate_versions(duckdb_version: str) -> list[str]:
     return list(dict.fromkeys([encoded, normal]))
 
 
+def version_key(version: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in version.split("."))
+
+
 def resolve_crate_version(duckdb_version: str) -> str:
     duckdb_versions = crate_versions("duckdb")
     sys_versions = crate_versions("libduckdb-sys")
+    major, minor, patch = duckdb_version_parts(duckdb_version)
+    encoded_prefix = f"{major}.{10000 + (minor * 100) + patch}."
+    encoded_matches = sorted(
+        (
+            version
+            for version in duckdb_versions.intersection(sys_versions)
+            if version.startswith(encoded_prefix)
+        ),
+        key=version_key,
+        reverse=True,
+    )
+    if encoded_matches:
+        return encoded_matches[0]
+
     for candidate in candidate_crate_versions(duckdb_version):
         if candidate in duckdb_versions and candidate in sys_versions:
             return candidate
@@ -303,13 +324,13 @@ def main() -> int:
         print(f"DuckDB release drift detected for {target.duckdb_version}:")
         for mismatch in mismatches:
             print(f"- {mismatch}")
-        return 1
+        return EXIT_ERROR if args.apply else EXIT_DRIFT
 
     print(
         "DuckDB release configuration is current: "
         f"{target.duckdb_version} / crate {target.crate_version} / CI {target.ci_tools_ref}"
     )
-    return 0
+    return EXIT_CURRENT
 
 
 if __name__ == "__main__":

--- a/scripts/validate_duckdb_release.sh
+++ b/scripts/validate_duckdb_release.sh
@@ -8,6 +8,7 @@ mkdir -p tmp
 
 python3 scripts/update_duckdb_release.py --check
 
+make clean_all
 cargo metadata --locked > tmp/cargo-metadata.json
 cargo check --locked
 make configure

--- a/src/vtab.rs
+++ b/src/vtab.rs
@@ -49,18 +49,26 @@ pub fn set_varchar_opt(output: &mut DataChunkHandle, col: usize, row: usize, val
 
 pub fn set_bool(output: &mut DataChunkHandle, col: usize, row: usize, val: bool) {
     let mut vec = output.flat_vector(col);
-    vec.as_mut_slice::<bool>()[row] = val;
+    // SAFETY: DuckDB owns this output vector for the current callback, `row` is
+    // within the batch we are writing, and the column is declared as BOOLEAN.
+    unsafe { vec.as_mut_slice::<bool>()[row] = val };
 }
 
 pub fn set_i64(output: &mut DataChunkHandle, col: usize, row: usize, val: i64) {
     let mut vec = output.flat_vector(col);
-    vec.as_mut_slice::<i64>()[row] = val;
+    // SAFETY: DuckDB owns this output vector for the current callback, `row` is
+    // within the batch we are writing, and the column is declared as BIGINT.
+    unsafe { vec.as_mut_slice::<i64>()[row] = val };
 }
 
 pub fn set_i64_opt(output: &mut DataChunkHandle, col: usize, row: usize, val: Option<i64>) {
     let mut vec = output.flat_vector(col);
     match val {
-        Some(v) => vec.as_mut_slice::<i64>()[row] = v,
+        Some(v) => {
+            // SAFETY: DuckDB owns this output vector for the current callback,
+            // `row` is within the batch we are writing, and the column is BIGINT.
+            unsafe { vec.as_mut_slice::<i64>()[row] = v };
+        }
         None => vec.set_null(row),
     }
 }


### PR DESCRIPTION
## Summary

Updates agent_data for DuckDB v1.5.3 and hardens the release monitor after the scheduled monitor run exposed a real compatibility issue.

- retargets build metadata and examples to DuckDB v1.5.3
- updates duckdb/libduckdb-sys to the latest v1.5.3 crate patch, 1.10503.1
- adds SAFETY-documented unsafe blocks required by the new FlatVector::as_mut_slice API
- improves release updater crate patch selection
- distinguishes release drift from operational errors in the monitor workflow
- makes failure issue reporting self-contained by creating the drift label if needed
- cleans stale build/configuration state before release validation

## Validation

- python3 scripts/update_duckdb_release.py --check
- python3 scripts/update_duckdb_release.py --check --duckdb-version v1.5.2 returns drift code 10
- python3 -m py_compile scripts/update_duckdb_release.py scripts/smoke_duckdb_release.py scripts/verify_community_publication.py scripts/prepare_community_extension_pr.py
- workflow YAML parsed with PyYAML
- cargo check --locked
- scripts/validate_duckdb_release.sh
