### PR TITLE
Fix DuckDB next metadata resolution

### DIFF
--- a/.github/workflows/duckdb-next-compat.yml
+++ b/.github/workflows/duckdb-next-compat.yml
@@ -20,8 +20,39 @@ permissions:
   contents: read
 
 jobs:
+  metadata-preflight:
+    name: Resolve DuckDB next metadata
+    runs-on: ubuntu-latest
+    outputs:
+      duckdb_metadata_version: ${{ steps.metadata.outputs.duckdb_metadata_version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install DuckDB pre-release
+        run: python -m pip install --pre duckdb
+
+      - name: Resolve metadata version
+        id: metadata
+        run: |
+          duckdb_version="${{ inputs.duckdb_version || 'main' }}"
+          metadata_version="$(python scripts/duckdb_metadata_version.py --duckdb-git-version "$duckdb_version")"
+          pragma_version="$(python -c 'import duckdb; print(duckdb.connect().execute("PRAGMA version").fetchone())')"
+          echo "duckdb_metadata_version=$metadata_version" >> "$GITHUB_OUTPUT"
+          {
+            echo "## DuckDB next metadata preflight"
+            echo ""
+            echo "- duckdb_version input: \`$duckdb_version\`"
+            echo "- metadata version: \`$metadata_version\`"
+            echo "- PRAGMA version: \`$pragma_version\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   duckdb-next-build:
     name: Build against DuckDB next
+    needs: metadata-preflight
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     with:
       duckdb_version: ${{ inputs.duckdb_version || 'main' }}

--- a/.github/workflows/duckdb-next-compat.yml
+++ b/.github/workflows/duckdb-next-compat.yml
@@ -60,3 +60,5 @@ jobs:
       extension_name: agent_data
       extra_toolchains: rust
       exclude_archs: "wasm_mvp;wasm_eh;wasm_threads;linux_amd64_musl"
+      test_config: >-
+        {"test_env_variables":{"TARGET_DUCKDB_VERSION":"${{ needs.metadata-preflight.outputs.duckdb_metadata_version }}"}}

--- a/Makefile
+++ b/Makefile
@@ -20,15 +20,17 @@ include extension-ci-tools/makefiles/c_api_extensions/rust.Makefile
 ifeq ($(TARGET_DUCKDB_VERSION),__AGENT_DATA_AUTO__)
   RESOLVE_DUCKDB_METADATA_VERSION = scripts/duckdb_metadata_version.py --duckdb-git-version "$(DUCKDB_GIT_VERSION)" --default "$(DEFAULT_TARGET_DUCKDB_VERSION)"
   override TARGET_DUCKDB_VERSION = $(shell $(PYTHON_VENV_BIN) $(RESOLVE_DUCKDB_METADATA_VERSION) 2>/dev/null || $(PYTHON_BIN) $(RESOLVE_DUCKDB_METADATA_VERSION))
-  ifeq ($(TARGET_DUCKDB_VERSION),)
-    $(error Could not resolve TARGET_DUCKDB_VERSION)
-  endif
 endif
+check_target_duckdb_version:
+	@test -n "$(TARGET_DUCKDB_VERSION)" || (echo "Could not resolve TARGET_DUCKDB_VERSION" >&2; exit 1)
 
 configure: venv platform extension_version
 
 debug: build_extension_library_debug build_extension_with_metadata_debug
+
 release: build_extension_library_release build_extension_with_metadata_release
+
+build_extension_library_debug build_extension_library_release build_extension_with_metadata_debug build_extension_with_metadata_release: check_target_duckdb_version
 
 test: test_debug
 test_debug: test_extension_debug

--- a/Makefile
+++ b/Makefile
@@ -18,13 +18,19 @@ include extension-ci-tools/makefiles/c_api_extensions/base.Makefile
 include extension-ci-tools/makefiles/c_api_extensions/rust.Makefile
 
 ifeq ($(TARGET_DUCKDB_VERSION),__AGENT_DATA_AUTO__)
-  RESOLVE_DUCKDB_METADATA_VERSION = scripts/duckdb_metadata_version.py --duckdb-git-version "$(DUCKDB_GIT_VERSION)" --default "$(DEFAULT_TARGET_DUCKDB_VERSION)"
+  EFFECTIVE_DUCKDB_GIT_VERSION = $(if $(DUCKDB_GIT_VERSION),$(DUCKDB_GIT_VERSION),$(shell cat configure/duckdb_git_version.txt 2>/dev/null))
+  RESOLVE_DUCKDB_METADATA_VERSION = scripts/duckdb_metadata_version.py --duckdb-git-version "$(EFFECTIVE_DUCKDB_GIT_VERSION)" --default "$(DEFAULT_TARGET_DUCKDB_VERSION)"
   override TARGET_DUCKDB_VERSION = $(shell $(PYTHON_VENV_BIN) $(RESOLVE_DUCKDB_METADATA_VERSION) 2>/dev/null || $(PYTHON_BIN) $(RESOLVE_DUCKDB_METADATA_VERSION))
 endif
 check_target_duckdb_version:
 	@test -n "$(TARGET_DUCKDB_VERSION)" || (echo "Could not resolve TARGET_DUCKDB_VERSION" >&2; exit 1)
 
-configure: venv platform extension_version
+configure: venv platform extension_version duckdb_git_version
+
+.PHONY: duckdb_git_version
+duckdb_git_version:
+	@mkdir -p configure
+	@printf '%s\n' "$(DUCKDB_GIT_VERSION)" > configure/duckdb_git_version.txt
 
 debug: build_extension_library_debug build_extension_with_metadata_debug
 

--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,19 @@ EXTENSION_NAME=agent_data
 USE_UNSTABLE_C_API=1
 
 # Target DuckDB version
-TARGET_DUCKDB_VERSION=v1.5.3
+DEFAULT_TARGET_DUCKDB_VERSION := v1.5.3
+TARGET_DUCKDB_VERSION ?= __AGENT_DATA_AUTO__
 
 all: configure debug
 
 # Include makefiles from DuckDB
 include extension-ci-tools/makefiles/c_api_extensions/base.Makefile
 include extension-ci-tools/makefiles/c_api_extensions/rust.Makefile
+
+ifeq ($(TARGET_DUCKDB_VERSION),__AGENT_DATA_AUTO__)
+  RESOLVE_DUCKDB_METADATA_VERSION = scripts/duckdb_metadata_version.py --duckdb-git-version "$(DUCKDB_GIT_VERSION)" --default "$(DEFAULT_TARGET_DUCKDB_VERSION)"
+  override TARGET_DUCKDB_VERSION = $(shell $(PYTHON_VENV_BIN) $(RESOLVE_DUCKDB_METADATA_VERSION) 2>/dev/null || $(PYTHON_BIN) $(RESOLVE_DUCKDB_METADATA_VERSION))
+endif
 
 configure: venv platform extension_version
 

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ include extension-ci-tools/makefiles/c_api_extensions/rust.Makefile
 ifeq ($(TARGET_DUCKDB_VERSION),__AGENT_DATA_AUTO__)
   RESOLVE_DUCKDB_METADATA_VERSION = scripts/duckdb_metadata_version.py --duckdb-git-version "$(DUCKDB_GIT_VERSION)" --default "$(DEFAULT_TARGET_DUCKDB_VERSION)"
   override TARGET_DUCKDB_VERSION = $(shell $(PYTHON_VENV_BIN) $(RESOLVE_DUCKDB_METADATA_VERSION) 2>/dev/null || $(PYTHON_BIN) $(RESOLVE_DUCKDB_METADATA_VERSION))
+  ifeq ($(TARGET_DUCKDB_VERSION),)
+    $(error Could not resolve TARGET_DUCKDB_VERSION)
+  endif
 endif
 
 configure: venv platform extension_version

--- a/scripts/duckdb_metadata_version.py
+++ b/scripts/duckdb_metadata_version.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import re
+import subprocess
 import sys
 from collections.abc import Callable
 from pathlib import Path
@@ -13,13 +14,36 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 
 
-def duckdb_source_id() -> str:
+def duckdb_python_source_id() -> str:
     import duckdb
 
     row = duckdb.connect().execute("PRAGMA version").fetchone()
     if row is None or len(row) < 2 or not row[1]:
         raise RuntimeError(f"Could not read DuckDB source id from PRAGMA version: {row!r}")
     return str(row[1])
+
+
+def duckdb_git_source_id(duckdb_dir: Path = ROOT / "duckdb") -> str:
+    result = subprocess.run(
+        ["git", "-C", str(duckdb_dir), "rev-parse", "--short=10", "HEAD"],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    source_id = result.stdout.strip()
+    if not source_id:
+        raise RuntimeError(f"Could not read DuckDB source id from git repository {duckdb_dir}")
+    return source_id
+
+
+def duckdb_source_id() -> str:
+    errors: list[str] = []
+    for resolver in (duckdb_python_source_id, duckdb_git_source_id):
+        try:
+            return resolver()
+        except Exception as exc:
+            errors.append(str(exc))
+    raise RuntimeError("Could not resolve DuckDB source id: " + "; ".join(errors))
 
 
 def resolve_metadata_version(

--- a/scripts/duckdb_metadata_version.py
+++ b/scripts/duckdb_metadata_version.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Resolve the DuckDB version/source id to stamp into extension metadata."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def duckdb_source_id() -> str:
+    import duckdb
+
+    row = duckdb.connect().execute("PRAGMA version").fetchone()
+    if row is None or len(row) < 2 or not row[1]:
+        raise RuntimeError(f"Could not read DuckDB source id from PRAGMA version: {row!r}")
+    return str(row[1])
+
+
+def resolve_metadata_version(
+    duckdb_git_version: str | None,
+    default: str,
+    source_id: Callable[[], str] = duckdb_source_id,
+) -> str:
+    version = (duckdb_git_version or "").strip()
+    if not version:
+        return default
+    if version == "main":
+        return source_id()
+    return version
+
+
+def default_metadata_version(makefile_path: Path = ROOT / "Makefile") -> str:
+    text = makefile_path.read_text()
+    match = re.search(r"^DEFAULT_TARGET_DUCKDB_VERSION\s*:?=\s*(.+)$", text, flags=re.MULTILINE)
+    if not match:
+        raise RuntimeError(f"Could not parse DEFAULT_TARGET_DUCKDB_VERSION from {makefile_path}")
+    return match.group(1).strip()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--duckdb-git-version", default="")
+    parser.add_argument("--default")
+    args = parser.parse_args()
+
+    try:
+        print(resolve_metadata_version(args.duckdb_git_version, args.default or default_metadata_version()))
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_duckdb_metadata_version.py
+++ b/scripts/test_duckdb_metadata_version.py
@@ -8,6 +8,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 import duckdb_metadata_version
 
@@ -56,6 +57,29 @@ class DuckDBMetadataVersionTests(unittest.TestCase):
             makefile = Path(temp_dir) / "Makefile"
             makefile.write_text("DEFAULT_TARGET_DUCKDB_VERSION := v1.5.4\n")
             self.assertEqual(duckdb_metadata_version.default_metadata_version(makefile), "v1.5.4")
+
+    def test_duckdb_source_id_falls_back_to_git(self) -> None:
+        with mock.patch.object(
+            duckdb_metadata_version,
+            "duckdb_python_source_id",
+            side_effect=RuntimeError("missing duckdb"),
+        ):
+            with mock.patch.object(duckdb_metadata_version, "duckdb_git_source_id", return_value="abcdef1234"):
+                self.assertEqual(duckdb_metadata_version.duckdb_source_id(), "abcdef1234")
+
+    def test_duckdb_source_id_reports_all_failures(self) -> None:
+        with mock.patch.object(
+            duckdb_metadata_version,
+            "duckdb_python_source_id",
+            side_effect=RuntimeError("missing duckdb"),
+        ):
+            with mock.patch.object(
+                duckdb_metadata_version,
+                "duckdb_git_source_id",
+                side_effect=RuntimeError("missing git checkout"),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "missing duckdb.*missing git checkout"):
+                    duckdb_metadata_version.duckdb_source_id()
 
 
 if __name__ == "__main__":

--- a/scripts/test_duckdb_metadata_version.py
+++ b/scripts/test_duckdb_metadata_version.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Tests for duckdb_metadata_version.py."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import duckdb_metadata_version
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "duckdb_metadata_version.py"
+
+
+class DuckDBMetadataVersionTests(unittest.TestCase):
+    def test_default_without_duckdb_git_version(self) -> None:
+        self.assertEqual(
+            duckdb_metadata_version.resolve_metadata_version("", "v1.5.3", lambda: "unexpected"),
+            "v1.5.3",
+        )
+
+    def test_release_ref_uses_ref(self) -> None:
+        self.assertEqual(
+            duckdb_metadata_version.resolve_metadata_version("v1.5.3", "v1.5.2", lambda: "unexpected"),
+            "v1.5.3",
+        )
+
+    def test_main_uses_duckdb_source_id(self) -> None:
+        self.assertEqual(
+            duckdb_metadata_version.resolve_metadata_version("main", "v1.5.3", lambda: "abc123"),
+            "abc123",
+        )
+
+    def test_main_source_id_failure_is_not_silent(self) -> None:
+        def fail() -> str:
+            raise RuntimeError("missing duckdb")
+
+        with self.assertRaisesRegex(RuntimeError, "missing duckdb"):
+            duckdb_metadata_version.resolve_metadata_version("main", "v1.5.3", fail)
+
+    def test_cli_default_path_does_not_import_duckdb(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "--default", "v1.5.3"],
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        self.assertEqual(result.stdout.strip(), "v1.5.3")
+
+    def test_default_metadata_version_reads_makefile_default(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            makefile = Path(temp_dir) / "Makefile"
+            makefile.write_text("DEFAULT_TARGET_DUCKDB_VERSION := v1.5.4\n")
+            self.assertEqual(duckdb_metadata_version.default_metadata_version(makefile), "v1.5.4")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/update_duckdb_release.py
+++ b/scripts/update_duckdb_release.py
@@ -187,8 +187,8 @@ def apply_target(target: ReleaseTarget, update_lockfile: bool) -> None:
     )
     replace(
         ROOT / "Makefile",
-        r"^TARGET_DUCKDB_VERSION=.*$",
-        f"TARGET_DUCKDB_VERSION={target.duckdb_version}",
+        r"^DEFAULT_TARGET_DUCKDB_VERSION\s*:?=\s*.+$",
+        f"DEFAULT_TARGET_DUCKDB_VERSION := {target.duckdb_version}",
     )
     replace(
         EXTENSION_WORKFLOW,
@@ -234,7 +234,11 @@ def parse_current_files() -> dict[str, str]:
         "metadata.excluded_archs": read_metadata().excluded_archs,
         "cargo.duckdb": match_one(r'duckdb = \{ version = "=([^"]+)"', cargo, "Cargo.toml duckdb"),
         "cargo.libduckdb-sys": match_one(r'libduckdb-sys = "=([^"]+)"', cargo, "Cargo.toml libduckdb-sys"),
-        "makefile.duckdb_version": match_one(r"^TARGET_DUCKDB_VERSION=(.+)$", makefile, "Makefile"),
+        "makefile.duckdb_version": match_one(
+            r"^DEFAULT_TARGET_DUCKDB_VERSION\s*:?=\s*(.+)$",
+            makefile,
+            "Makefile",
+        ),
         "workflow.ci_tools_ref": match_one(
             r"uses: duckdb/extension-ci-tools/\.github/workflows/_extension_distribution\.yml@(.+)",
             workflow,


### PR DESCRIPTION
## Summary

- resolve DuckDB extension metadata dynamically for `DUCKDB_GIT_VERSION=main` builds using the installed DuckDB `PRAGMA version` source id
- keep stable/release builds pinned to the configured default DuckDB version
- add a next-compat metadata preflight so scheduled failures expose the resolved DuckDB metadata before the build matrix starts
- update release automation parsing so future stable release bumps continue to update/check the Makefile default

## Validation

- `python3 -m py_compile scripts/duckdb_metadata_version.py scripts/test_duckdb_metadata_version.py scripts/update_duckdb_release.py`
- `python3 scripts/test_duckdb_metadata_version.py`
- `python3 scripts/duckdb_metadata_version.py`
- `python3 scripts/update_duckdb_release.py --duckdb-version v1.5.3 --check`
- parsed `.github/workflows/duckdb-next-compat.yml` with PyYAML
- `cargo check --locked`
- `scripts/validate_duckdb_release.sh`
- `DUCKDB_GIT_VERSION=main make clean_configure configure release` followed by DuckDB pre-release load smoke

## Root cause

The next compatibility workflow sets `duckdb_version: main`, but the extension metadata was always stamped as `v1.5.3`. Because this extension uses `USE_UNSTABLE_C_API=1`, DuckDB rejects extensions whose stamped metadata does not match the exact development source id under test.
