### PR TITLE
ci: make DuckDB release monitor robust to version bumps

### DIFF
--- a/.github/workflows/duckdb-release-monitor.yml
+++ b/.github/workflows/duckdb-release-monitor.yml
@@ -27,6 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - uses: astral-sh/setup-uv@v5
 
@@ -54,9 +56,17 @@ jobs:
               ;;
           esac
 
-      - name: Fail pull request on release drift or check error
-        if: steps.drift.outputs.status != 'current' && github.event_name == 'pull_request'
+      - name: Warn on DuckDB release drift (pull request)
+        if: steps.drift.outputs.status == 'drift' && github.event_name == 'pull_request'
+        run: echo "::warning::DuckDB is ahead of the pinned release; the scheduled monitor will open an update PR. This is informational and does not block this PR."
+
+      - name: Fail pull request on check error
+        if: steps.drift.outputs.status == 'error' && github.event_name == 'pull_request'
         run: exit 1
+
+      - name: Verify release config consistency (pull request)
+        if: github.event_name == 'pull_request'
+        run: python3 scripts/update_duckdb_release.py --check-consistency
 
       - name: Apply DuckDB release update
         if: steps.drift.outputs.status == 'drift' && github.event_name != 'pull_request'

--- a/scripts/test_update_duckdb_release.py
+++ b/scripts/test_update_duckdb_release.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Tests for update_duckdb_release.py."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+from unittest import mock
+
+import update_duckdb_release
+from update_duckdb_release import ReleaseTarget
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "update_duckdb_release.py"
+
+
+class ConsistencyCheckTests(unittest.TestCase):
+    def test_repo_tree_is_internally_consistent(self) -> None:
+        self.assertEqual(update_duckdb_release.consistency_mismatches(), [])
+
+    def test_consistency_check_does_not_use_network(self) -> None:
+        def fail(*_args, **_kwargs):
+            raise AssertionError("consistency check must not contact the network")
+
+        with mock.patch.object(update_duckdb_release, "http_json", side_effect=fail):
+            self.assertEqual(update_duckdb_release.consistency_mismatches(), [])
+
+    def test_desynced_metadata_is_detected(self) -> None:
+        bogus = ReleaseTarget(
+            duckdb_version="v9.9.9",
+            python_version="9.9.9",
+            crate_version="9.99999.0",
+            ci_tools_ref="v9.9-bogus",
+            excluded_archs="none",
+        )
+        with mock.patch.object(update_duckdb_release, "read_metadata", return_value=bogus):
+            mismatches = update_duckdb_release.consistency_mismatches()
+        self.assertTrue(mismatches)
+        # Metadata keys describe the source of truth itself and must never be reported.
+        self.assertFalse(any(item.startswith("metadata.") for item in mismatches))
+        self.assertTrue(any(item.startswith("makefile.") for item in mismatches))
+
+    def test_cli_check_consistency_passes_on_repo(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "--check-consistency"],
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        self.assertIn("internally consistent", result.stdout)
+
+    def test_cli_rejects_multiple_modes(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "--check", "--check-consistency"],
+            text=True,
+            capture_output=True,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("exactly one of", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/update_duckdb_release.py
+++ b/scripts/update_duckdb_release.py
@@ -293,6 +293,26 @@ def check_target(target: ReleaseTarget) -> list[str]:
     return mismatches
 
 
+def consistency_mismatches() -> list[str]:
+    """Check that the version pinned in duckdb-release.toml is applied consistently.
+
+    Uses the metadata file as the source of truth and verifies every other file matches
+    it. Unlike the latest-release check, this performs no network calls and does not care
+    whether the pinned version is behind the newest upstream DuckDB release.
+    """
+    target = read_metadata()
+    current = parse_current_files()
+    expected = expected_values(target)
+    mismatches: list[str] = []
+    for key, expected_value in expected.items():
+        if key.startswith("metadata."):
+            continue
+        current_value = current.get(key)
+        if current_value != expected_value:
+            mismatches.append(f"{key}: current={current_value!r} expected={expected_value!r}")
+    return mismatches
+
+
 def resolve_target(duckdb_version: str | None) -> ReleaseTarget:
     version = duckdb_version or latest_duckdb_release()
     bare_version = version.removeprefix("v")
@@ -311,13 +331,35 @@ def main() -> int:
     parser.add_argument("--check", action="store_true", help="Check configured versions for drift")
     parser.add_argument("--apply", action="store_true", help="Apply the resolved version to local files")
     parser.add_argument(
+        "--check-consistency",
+        action="store_true",
+        help=(
+            "Check that the version pinned in duckdb-release.toml is applied consistently "
+            "across all files, without contacting the network or the latest upstream release"
+        ),
+    )
+    parser.add_argument(
         "--no-lockfile-update",
         action="store_true",
         help="Do not run cargo update after editing Cargo.toml",
     )
     args = parser.parse_args()
-    if args.check == args.apply:
-        parser.error("choose exactly one of --check or --apply")
+    selected = sum(bool(flag) for flag in (args.check, args.apply, args.check_consistency))
+    if selected != 1:
+        parser.error("choose exactly one of --check, --apply or --check-consistency")
+
+    if args.check_consistency:
+        mismatches = consistency_mismatches()
+        if mismatches:
+            print("DuckDB release configuration is inconsistent with duckdb-release.toml:")
+            for mismatch in mismatches:
+                print(f"- {mismatch}")
+            return EXIT_ERROR
+        print(
+            "DuckDB release configuration is internally consistent: "
+            f"{read_metadata().duckdb_version}"
+        )
+        return EXIT_CURRENT
 
     target = resolve_target(args.duckdb_version)
     if args.apply:


### PR DESCRIPTION
## Why

The scheduled DuckDB release monitor has never managed to land an automated version-bump PR. Investigating the failing runs showed two distinct problems behind every failed bump:

1. **Submodule not checked out.** The monitor's `actions/checkout` did not fetch submodules, so the local validation build could not resolve the Makefile includes provided by the `extension-ci-tools` submodule (`extension-ci-tools/makefiles/c_api_extensions/rust.Makefile`). `make` aborted before any build/test ran, so the auto-update PR was never opened (this is what blocked the v1.5.4 bump on 2026-06-22).
2. **Noisy hard-fail on pull requests.** Any drift between the pinned DuckDB version and the newest upstream release hard-failed *every* PR, putting a spurious red check on unrelated feature branches whenever a new DuckDB release was pending.

## What

- Check out submodules recursively in the release monitor so validation can build.
- On pull requests, report drift-vs-upstream as a non-blocking `::warning` instead of failing. Genuine check errors still fail the PR.
- Add a network-free `--check-consistency` mode to `update_duckdb_release.py` that verifies the version pinned in `duckdb-release.toml` is applied consistently across `Cargo.toml`, the `Makefile`, the distribution workflow and example pyprojects. The monitor runs this on PRs so an inconsistent hand edit of the release files still fails fast.
- Add unit + CLI tests for the new consistency check.

## Validation

Locally on a clean v1.5.4 build: all 17 SQL tests pass, `cargo test` passes, and 8 existing + 5 new Python tests pass. The consistency check passes on the current tree and fails correctly when a file is desynced.
