### PR TITLE
ci: validate generated DuckDB update for internal consistency

### DIFF
--- a/scripts/validate_duckdb_release.sh
+++ b/scripts/validate_duckdb_release.sh
@@ -6,7 +6,7 @@ cd "$ROOT"
 
 mkdir -p tmp
 
-python3 scripts/update_duckdb_release.py --check
+python3 scripts/update_duckdb_release.py --check-consistency
 
 make clean_all
 cargo metadata --locked > tmp/cargo-metadata.json


### PR DESCRIPTION
Follow-up to #15. The release monitor's `validate_duckdb_release.sh` began by re-running the drift check against the **latest** upstream release. Since validation runs *after* the update is applied, this fails whenever the applied version isn't the network-latest (e.g. a dispatched run pinned to an older version, or a new release landing mid-run).

Switch the pre-build check to the network-free `--check-consistency` mode, which verifies the applied version is propagated consistently across all files. This makes the monitor's validate step correct for both scheduled latest bumps and manually dispatched version targets.