### PR TITLE
feat: Grok Build + Cursor agent-transcripts for read_*

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A [DuckDB extension](https://duckdb.org/community_extensions/list_of_extensions) written in Rust for querying, analysing and inspecting AI coding agents history. Read conversations, plans, todos, history, and usage stats directly from your local agent data directories.
 
-**Supported agents:** [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (`~/.claude`), Claude Desktop ("Cowork", `~/Library/Application Support/Claude`), [GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli) (`~/.copilot`), [Cursor](https://cursor.com) (`~/Library/Application Support/Cursor/User/globalStorage/state.vscdb`, `source='cursor'`), [OpenAI Codex CLI](https://openai.com/codex) (`~/.codex`, `source='codex'`) and [Gemini CLI](https://github.com/google-gemini/gemini-cli) (`~/.gemini`).
+**Supported agents:** [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (`~/.claude`), Claude Desktop ("Cowork", `~/Library/Application Support/Claude`), [GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli) (`~/.copilot`), [Cursor](https://cursor.com) (`state.vscdb` **or** `~/.cursor/projects/*/agent-transcripts/`), [OpenAI Codex CLI](https://openai.com/codex) (`~/.codex`), [Gemini CLI](https://github.com/google-gemini/gemini-cli) (`~/.gemini`), and [Grok Build](https://x.ai) (`~/.grok`, `source='grok'`).
 
 Written in 🦀 Rust.
 
@@ -85,7 +85,7 @@ GROUP BY tool_name
 ORDER BY uses DESC
 LIMIT 10;
 
--- Compare activity across Claude, Copilot, and Gemini
+-- Compare activity across Claude, Copilot, Gemini, Cursor, and Grok
 SELECT source, COUNT(DISTINCT session_id) AS sessions, COUNT(*) AS messages
 FROM (
     SELECT * FROM read_conversations(path='~/.claude')
@@ -93,8 +93,16 @@ FROM (
     SELECT * FROM read_conversations(path='~/.copilot')
     UNION ALL
     SELECT * FROM read_conversations(path='~/.gemini')
+    UNION ALL
+    SELECT * FROM read_conversations(path='~/.cursor')
+    UNION ALL
+    SELECT * FROM read_conversations(path='~/.grok')
 )
 GROUP BY source;
+
+-- Grok plans (plan.md per session)
+SELECT session_id, plan_name, length(content) AS chars
+FROM read_plans(path='~/.grok', source='grok');
 ```
 
 ### Default Behavior

--- a/src/conversations.rs
+++ b/src/conversations.rs
@@ -917,6 +917,314 @@ impl Conversations {
     }
 }
 
+// ─── Cursor agent-transcripts (CLI / projects layout) ───
+//
+// Path: ~/.cursor/projects/<project>/agent-transcripts/<session-id>/<session-id>.jsonl
+// Lines: {"role":"user"|"assistant","message":{"content":[...]}}
+
+impl Conversations {
+    fn load_cursor_agent_transcript_rows(base_path: &std::path::Path) -> Vec<ConversationRow> {
+        let projects = base_path.join("projects");
+        if !projects.is_dir() {
+            return Vec::new();
+        }
+        let mut rows = Vec::new();
+        let mut project_dirs: Vec<_> = std::fs::read_dir(&projects)
+            .into_iter()
+            .flatten()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().is_dir())
+            .collect();
+        project_dirs.sort_by_key(|e| e.file_name());
+
+        for pe in project_dirs {
+            let project_dir = pe.file_name().to_string_lossy().to_string();
+            let at = pe.path().join("agent-transcripts");
+            if !at.is_dir() {
+                continue;
+            }
+            let mut sessions: Vec<_> = std::fs::read_dir(&at)
+                .into_iter()
+                .flatten()
+                .filter_map(|e| e.ok())
+                .filter(|e| e.path().is_dir())
+                .collect();
+            sessions.sort_by_key(|e| e.file_name());
+
+            for se in sessions {
+                let session_id = se.file_name().to_string_lossy().to_string();
+                let jsonl = se.path().join(format!("{session_id}.jsonl"));
+                let path = if jsonl.is_file() {
+                    jsonl
+                } else {
+                    // any *.jsonl in the session dir
+                    match std::fs::read_dir(se.path())
+                        .into_iter()
+                        .flatten()
+                        .filter_map(|e| e.ok())
+                        .find(|e| e.path().extension().map_or(false, |x| x == "jsonl"))
+                    {
+                        Some(f) => f.path(),
+                        None => continue,
+                    }
+                };
+                let file = match std::fs::File::open(&path) {
+                    Ok(f) => f,
+                    Err(_) => continue,
+                };
+                let file_name = path
+                    .file_name()
+                    .map(|s| s.to_string_lossy().to_string())
+                    .unwrap_or_default();
+                for (line_number, line) in BufReader::new(file).lines().flatten().enumerate() {
+                    let line = line.trim().to_string();
+                    if line.is_empty() {
+                        continue;
+                    }
+                    let v: serde_json::Value = match serde_json::from_str(&line) {
+                        Ok(v) => v,
+                        Err(_) => continue,
+                    };
+                    let role = v
+                        .get("role")
+                        .and_then(|r| r.as_str())
+                        .unwrap_or("unknown");
+                    let content = v
+                        .get("message")
+                        .and_then(|m| m.get("content"))
+                        .map(utils::extract_text_content);
+                    rows.push(ConversationRow {
+                        source: "cursor".to_string(),
+                        session_id: session_id.clone(),
+                        project_path: project_dir.clone(),
+                        project_dir: project_dir.clone(),
+                        file_name: file_name.clone(),
+                        line_number: line_number as i64 + 1,
+                        message_type: role.to_string(),
+                        message_role: Some(role.to_string()),
+                        message_content: content,
+                        ..Default::default()
+                    });
+                }
+            }
+        }
+        rows
+    }
+
+    // ─── Grok Build ───
+    //
+    // Path: ~/.grok/sessions/<url-encoded-cwd>/<session-id>/
+    // Prefer chat_history.jsonl (compact messages). Falls back to empty if missing.
+
+    fn load_grok_rows(base_path: &std::path::Path) -> Vec<ConversationRow> {
+        let mut session_dirs = Vec::new();
+
+        // Single session directory
+        if base_path.join("chat_history.jsonl").is_file()
+            || base_path.join("summary.json").is_file()
+        {
+            session_dirs.push(base_path.to_path_buf());
+        }
+
+        let sessions = base_path.join("sessions");
+        if sessions.is_dir() {
+            for cwd_ent in std::fs::read_dir(&sessions).into_iter().flatten().flatten() {
+                if !cwd_ent.path().is_dir() {
+                    continue;
+                }
+                for sess in std::fs::read_dir(cwd_ent.path()).into_iter().flatten().flatten() {
+                    let sp = sess.path();
+                    if sp.is_dir()
+                        && (sp.join("chat_history.jsonl").is_file()
+                            || sp.join("summary.json").is_file())
+                    {
+                        session_dirs.push(sp);
+                    }
+                }
+            }
+        }
+        session_dirs.sort();
+
+        let mut rows = Vec::new();
+        for sess_path in session_dirs {
+            let session_id = sess_path
+                .file_name()
+                .map(|s| s.to_string_lossy().to_string())
+                .unwrap_or_default();
+            let cwd_enc = sess_path
+                .parent()
+                .and_then(|p| p.file_name())
+                .map(|s| s.to_string_lossy().to_string())
+                .unwrap_or_default();
+            let project_path = utils::percent_decode_loose(&cwd_enc);
+
+            // optional summary for model / title
+            let (model, slug) = Self::grok_summary_meta(&sess_path);
+
+            let hist = sess_path.join("chat_history.jsonl");
+            if !hist.is_file() {
+                continue;
+            }
+            let file = match std::fs::File::open(&hist) {
+                Ok(f) => f,
+                Err(_) => continue,
+            };
+            for (line_number, line) in BufReader::new(file).lines().flatten().enumerate() {
+                let line = line.trim().to_string();
+                if line.is_empty() {
+                    continue;
+                }
+                let v: serde_json::Value = match serde_json::from_str(&line) {
+                    Ok(v) => v,
+                    Err(_) => continue,
+                };
+                let msg_type = v
+                    .get("type")
+                    .and_then(|t| t.as_str())
+                    .unwrap_or("unknown");
+                // skip pure system preamble noise optionally still emit
+                let content = match v.get("content") {
+                    Some(c) => Some(utils::extract_text_content(c)),
+                    None => None,
+                };
+                let tool_calls = v.get("tool_calls");
+                let model_id = v
+                    .get("model_id")
+                    .and_then(|m| m.as_str())
+                    .map(String::from)
+                    .or_else(|| model.clone());
+
+                if let Some(arr) = tool_calls.and_then(|t| t.as_array()) {
+                    // assistant row with text
+                    if content.as_ref().map(|c| !c.is_empty()).unwrap_or(false) {
+                        rows.push(ConversationRow {
+                            source: "grok".to_string(),
+                            session_id: session_id.clone(),
+                            project_path: project_path.clone(),
+                            project_dir: cwd_enc.clone(),
+                            file_name: "chat_history.jsonl".to_string(),
+                            line_number: line_number as i64 + 1,
+                            message_type: "assistant".to_string(),
+                            message_role: Some("assistant".to_string()),
+                            message_content: content.clone(),
+                            model: model_id.clone(),
+                            slug: slug.clone(),
+                            cwd: Some(project_path.clone()),
+                            ..Default::default()
+                        });
+                    }
+                    for (ti, tc) in arr.iter().enumerate() {
+                        let tool_name = tc
+                            .get("function")
+                            .and_then(|f| f.get("name"))
+                            .or_else(|| tc.get("name"))
+                            .and_then(|n| n.as_str())
+                            .map(String::from);
+                        let tool_input = tc
+                            .get("function")
+                            .and_then(|f| f.get("arguments"))
+                            .or_else(|| tc.get("arguments"))
+                            .map(|a| {
+                                if a.is_string() {
+                                    a.as_str().unwrap_or("").to_string()
+                                } else {
+                                    a.to_string()
+                                }
+                            });
+                        let tool_use_id = tc
+                            .get("id")
+                            .and_then(|i| i.as_str())
+                            .map(String::from);
+                        rows.push(ConversationRow {
+                            source: "grok".to_string(),
+                            session_id: session_id.clone(),
+                            project_path: project_path.clone(),
+                            project_dir: cwd_enc.clone(),
+                            file_name: "chat_history.jsonl".to_string(),
+                            line_number: line_number as i64 + 1 + ti as i64,
+                            message_type: "tool_call".to_string(),
+                            message_role: Some("assistant".to_string()),
+                            model: model_id.clone(),
+                            tool_name,
+                            tool_use_id,
+                            tool_input,
+                            slug: slug.clone(),
+                            cwd: Some(project_path.clone()),
+                            ..Default::default()
+                        });
+                    }
+                    continue;
+                }
+
+                // tool result lines
+                if msg_type == "tool" || v.get("tool_call_id").is_some() {
+                    rows.push(ConversationRow {
+                        source: "grok".to_string(),
+                        session_id: session_id.clone(),
+                        project_path: project_path.clone(),
+                        project_dir: cwd_enc.clone(),
+                        file_name: "chat_history.jsonl".to_string(),
+                        line_number: line_number as i64 + 1,
+                        message_type: "tool_result".to_string(),
+                        message_role: Some("tool".to_string()),
+                        message_content: content,
+                        tool_use_id: v
+                            .get("tool_call_id")
+                            .and_then(|i| i.as_str())
+                            .map(String::from),
+                        slug: slug.clone(),
+                        cwd: Some(project_path.clone()),
+                        ..Default::default()
+                    });
+                    continue;
+                }
+
+                let role = match msg_type {
+                    "user" => "user",
+                    "assistant" => "assistant",
+                    "system" => "system",
+                    other => other,
+                };
+                rows.push(ConversationRow {
+                    source: "grok".to_string(),
+                    session_id: session_id.clone(),
+                    project_path: project_path.clone(),
+                    project_dir: cwd_enc.clone(),
+                    file_name: "chat_history.jsonl".to_string(),
+                    line_number: line_number as i64 + 1,
+                    message_type: role.to_string(),
+                    message_role: Some(role.to_string()),
+                    message_content: content,
+                    model: model_id,
+                    slug: slug.clone(),
+                    cwd: Some(project_path.clone()),
+                    ..Default::default()
+                });
+            }
+        }
+        rows
+    }
+
+    fn grok_summary_meta(sess_path: &std::path::Path) -> (Option<String>, Option<String>) {
+        let p = sess_path.join("summary.json");
+        let Ok(s) = std::fs::read_to_string(p) else {
+            return (None, None);
+        };
+        let Ok(v) = serde_json::from_str::<serde_json::Value>(&s) else {
+            return (None, None);
+        };
+        let model = v
+            .get("current_model_id")
+            .and_then(|m| m.as_str())
+            .map(String::from);
+        let slug = v
+            .get("generated_title")
+            .or_else(|| v.get("session_summary"))
+            .and_then(|t| t.as_str())
+            .map(String::from);
+        (model, slug)
+    }
+}
 
 // ─── TableFunc implementation ───
 
@@ -948,9 +1256,17 @@ impl TableFunc for Conversations {
             Provider::Claude => Self::load_claude_rows(&base_path),
             Provider::ClaudeDesktop => Self::load_claude_desktop_rows(&base_path),
             Provider::Copilot => Self::load_copilot_rows(&base_path),
-            Provider::Cursor => Self::load_cursor_rows(&base_path),
+            Provider::Cursor => {
+                // Prefer IDE vscdb when present; fall back to CLI agent-transcripts.
+                let mut rows = Self::load_cursor_rows(&base_path);
+                if rows.is_empty() {
+                    rows = Self::load_cursor_agent_transcript_rows(&base_path);
+                }
+                rows
+            }
             Provider::Codex => Self::load_codex_rows(&base_path),
             Provider::Gemini => Self::load_gemini_rows(&base_path),
+            Provider::Grok => Self::load_grok_rows(&base_path),
             Provider::Unknown => Vec::new(),
         }
     }

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -9,29 +9,42 @@ pub enum Provider {
     Cursor,
     Codex,
     Gemini,
+    Grok,
     Unknown,
 }
 
 /// Auto-detect provider from directory structure.
 /// - `local-agent-mode-sessions/` directory → Claude Desktop
-/// - `projects/` directory → Claude
+/// - Cursor IDE: `state.vscdb` file (direct or in dir) → Cursor
+/// - Cursor CLI: `projects/*/agent-transcripts/` → Cursor (before Claude `projects/`)
+/// - Claude Code: `projects/` with session `*.jsonl` at projects/<enc>/*.jsonl → Claude
 /// - `session-state/` directory → Copilot
-/// - `state.vscdb` file (passed directly or found in the directory) → Cursor
-/// - `sessions/` with `YYYY/` date partitions (rollout files) → Codex
-/// - `tmp/` directory + `installation_id` file → Gemini CLI (`~/.gemini`)
+/// - Grok Build: `sessions/<cwd-enc>/<session-id>/summary.json` (or chat_history.jsonl)
+/// - Codex: `sessions/YYYY/` date partitions (rollout files)
+/// - Gemini CLI: `tmp/` + `installation_id` → Gemini (`~/.gemini`)
 pub fn detect_provider(path: &Path) -> Provider {
     if path.join("local-agent-mode-sessions").is_dir() {
         return Provider::ClaudeDesktop;
     }
-    if path.join("projects").is_dir() {
-        return Provider::Claude;
+    // Cursor: the vscdb file may be passed directly, or its parent directory.
+    if path.extension().map_or(false, |e| e == "vscdb") || path.join("state.vscdb").is_file() {
+        return Provider::Cursor;
+    }
+    // Cursor agent-transcripts under projects/ — must run BEFORE Claude's projects/ check
+    // because ~/.cursor also has a projects/ tree.
+    if has_cursor_agent_transcripts(path) {
+        return Provider::Cursor;
     }
     if path.join("session-state").is_dir() {
         return Provider::Copilot;
     }
-    // Cursor: the vscdb file may be passed directly, or its parent directory.
-    if path.extension().map_or(false, |e| e == "vscdb") || path.join("state.vscdb").is_file() {
-        return Provider::Cursor;
+    // Claude Code: projects/<enc>/*.jsonl (not agent-transcripts nested layout)
+    if path.join("projects").is_dir() && has_claude_project_jsonl(path) {
+        return Provider::Claude;
+    }
+    // Grok Build before Codex: both use sessions/, different shapes
+    if is_grok_home(path) {
+        return Provider::Grok;
     }
     // Codex partitions transcripts by date: sessions/YYYY/MM/DD/rollout-*.jsonl.
     let sessions = path.join("sessions");
@@ -51,13 +64,81 @@ pub fn detect_provider(path: &Path) -> Provider {
             return Provider::Codex;
         }
     }
-    // Gemini CLI keeps chats under `tmp/<project-hash>/chats/`. The `tmp/` name
-    // alone is too generic, so require the Gemini-specific `installation_id`
-    // file (written by the CLI to `~/.gemini`) as a corroborating marker.
+    // Gemini CLI keeps chats under `tmp/<project-hash>/chats/`.
     if path.join("tmp").is_dir() && path.join("installation_id").is_file() {
         return Provider::Gemini;
     }
     Provider::Unknown
+}
+
+/// Cursor CLI / IDE agent transcripts: projects/<name>/agent-transcripts/<id>/<id>.jsonl
+fn has_cursor_agent_transcripts(path: &Path) -> bool {
+    let projects = path.join("projects");
+    if !projects.is_dir() {
+        return false;
+    }
+    std::fs::read_dir(&projects)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .any(|e| e.path().join("agent-transcripts").is_dir())
+}
+
+/// Claude Code: at least one projects/<enc>/*.jsonl (files directly in project dir).
+fn has_claude_project_jsonl(path: &Path) -> bool {
+    let projects = path.join("projects");
+    if !projects.is_dir() {
+        return false;
+    }
+    for pe in std::fs::read_dir(&projects).into_iter().flatten().flatten() {
+        if !pe.path().is_dir() {
+            continue;
+        }
+        let has_jsonl = std::fs::read_dir(pe.path())
+            .into_iter()
+            .flatten()
+            .flatten()
+            .any(|f| f.path().extension().map_or(false, |e| e == "jsonl"));
+        if has_jsonl {
+            return true;
+        }
+    }
+    false
+}
+
+/// Grok Build home: sessions/<url-encoded-cwd>/<session-uuid>/summary.json
+/// or chat_history.jsonl / updates.jsonl.
+fn is_grok_home(path: &Path) -> bool {
+    // Direct path to a single session dir
+    if path.join("summary.json").is_file() || path.join("chat_history.jsonl").is_file() {
+        return true;
+    }
+    let sessions = path.join("sessions");
+    if !sessions.is_dir() {
+        return false;
+    }
+    // Prefer marker that is not Codex year partitions
+    for cwd_ent in std::fs::read_dir(&sessions).into_iter().flatten().flatten() {
+        let cwd_path = cwd_ent.path();
+        if !cwd_path.is_dir() {
+            continue;
+        }
+        let name = cwd_ent.file_name().to_string_lossy().to_string();
+        // Codex year folders are pure digits (YYYY)
+        if name.chars().all(|c| c.is_ascii_digit()) && name.len() == 4 {
+            continue;
+        }
+        for sess in std::fs::read_dir(&cwd_path).into_iter().flatten().flatten() {
+            let sp = sess.path();
+            if sp.join("summary.json").is_file()
+                || sp.join("chat_history.jsonl").is_file()
+                || sp.join("updates.jsonl").is_file()
+            {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 /// Parse an explicit source string into a Provider.
@@ -69,6 +150,7 @@ pub fn parse_source(source: &str) -> Provider {
         "cursor" => Provider::Cursor,
         "codex" => Provider::Codex,
         "gemini" => Provider::Gemini,
+        "grok" | "grok-build" => Provider::Grok,
         _ => Provider::Unknown,
     }
 }
@@ -82,4 +164,52 @@ pub fn resolve_provider(path: &Path, source: Option<&str>) -> Provider {
         }
     }
     detect_provider(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn tmp(label: &str) -> PathBuf {
+        let p = std::env::temp_dir().join(format!(
+            "agent_data_detect_{}_{}_{}",
+            std::process::id(),
+            label,
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    #[test]
+    fn cursor_agent_transcripts_not_claude() {
+        let root = tmp("cursor");
+        let at = root
+            .join("projects")
+            .join("foo")
+            .join("agent-transcripts")
+            .join("sid");
+        fs::create_dir_all(&at).unwrap();
+        fs::write(at.join("sid.jsonl"), "{}\n").unwrap();
+        assert_eq!(detect_provider(&root), Provider::Cursor);
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn grok_sessions_layout() {
+        let root = tmp("grok");
+        let sess = root
+            .join("sessions")
+            .join("%2FUsers%2Ftest")
+            .join("019f-session-id");
+        fs::create_dir_all(&sess).unwrap();
+        fs::write(sess.join("summary.json"), "{}").unwrap();
+        assert_eq!(detect_provider(&root), Provider::Grok);
+        let _ = fs::remove_dir_all(&root);
+    }
 }

--- a/src/history.rs
+++ b/src/history.rs
@@ -107,6 +107,7 @@ impl TableFunc for History {
             | Provider::Cursor
             | Provider::Codex
             | Provider::Gemini
+            | Provider::Grok
             | Provider::Unknown => Vec::new(),
         }
     }

--- a/src/plans.rs
+++ b/src/plans.rs
@@ -49,6 +49,58 @@ impl Plans {
             })
         }).collect()
     }
+
+    /// Grok: `sessions/<cwd-enc>/<session-id>/plan.md` (and plan.json when present).
+    fn load_grok_rows(base_path: &std::path::Path) -> Vec<PlanRow> {
+        let mut rows = Vec::new();
+        let mut session_dirs = Vec::new();
+        if base_path.join("plan.md").is_file() {
+            session_dirs.push(base_path.to_path_buf());
+        }
+        let sessions = base_path.join("sessions");
+        if sessions.is_dir() {
+            for cwd_ent in std::fs::read_dir(&sessions).into_iter().flatten().flatten() {
+                if !cwd_ent.path().is_dir() {
+                    continue;
+                }
+                for sess in std::fs::read_dir(cwd_ent.path()).into_iter().flatten().flatten() {
+                    let sp = sess.path();
+                    if sp.is_dir() && sp.join("plan.md").is_file() {
+                        session_dirs.push(sp);
+                    }
+                }
+            }
+        }
+        session_dirs.sort();
+        for sp in session_dirs {
+            let session_id = sp
+                .file_name()
+                .map(|s| s.to_string_lossy().to_string());
+            for name in ["plan.md", "plan.json"] {
+                let fp = sp.join(name);
+                if !fp.is_file() {
+                    continue;
+                }
+                let Ok(content) = std::fs::read_to_string(&fp) else {
+                    continue;
+                };
+                let file_size = std::fs::metadata(&fp).map(|m| m.len() as i64).unwrap_or(0);
+                rows.push(PlanRow {
+                    source: "grok".to_string(),
+                    session_id: session_id.clone(),
+                    plan_name: fp
+                        .file_stem()
+                        .map(|s| s.to_string_lossy().to_string())
+                        .unwrap_or_else(|| "plan".to_string()),
+                    file_name: name.to_string(),
+                    file_path: fp.to_string_lossy().to_string(),
+                    content,
+                    file_size,
+                });
+            }
+        }
+        rows
+    }
 }
 
 impl TableFunc for Plans {
@@ -75,6 +127,7 @@ impl TableFunc for Plans {
             // standalone plan files; Codex plans live inline in the rollout stream
             // and Gemini plan steps live inline in the chat transcript (no
             // standalone plan files). Return empty.
+            Provider::Grok => Self::load_grok_rows(&base_path),
             Provider::ClaudeDesktop
             | Provider::Cursor
             | Provider::Codex

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -56,6 +56,7 @@ impl TableFunc for Stats {
             | Provider::Cursor
             | Provider::Codex
             | Provider::Gemini
+            | Provider::Grok
             | Provider::Unknown => Vec::new(),
         }
     }

--- a/src/todos.rs
+++ b/src/todos.rs
@@ -137,6 +137,7 @@ impl TableFunc for Todos {
             | Provider::Cursor
             | Provider::Codex
             | Provider::Gemini
+            | Provider::Grok
             | Provider::Unknown => Vec::new(),
         }
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -13,6 +13,33 @@ pub fn resolve_data_path(path: Option<&str>) -> PathBuf {
     }
 }
 
+/// Best-effort percent-decode for Grok session cwd folder names (`%2FUsers%2F…`).
+pub fn percent_decode_loose(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            let h = |c: u8| -> Option<u8> {
+                match c {
+                    b'0'..=b'9' => Some(c - b'0'),
+                    b'a'..=b'f' => Some(c - b'a' + 10),
+                    b'A'..=b'F' => Some(c - b'A' + 10),
+                    _ => None,
+                }
+            };
+            if let (Some(a), Some(b)) = (h(bytes[i + 1]), h(bytes[i + 2])) {
+                out.push((a << 4) | b);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
 /// Expand ~ at the start of a path to the user's home directory.
 fn expand_tilde(path: &str) -> PathBuf {
     if path.starts_with("~/") || path == "~" {


### PR DESCRIPTION
## Summary
- **Grok Build** (`~/.grok`): detect `sessions/<cwd-enc>/<session-id>/summary.json|chat_history.jsonl`; `read_conversations` + `read_plans` (`plan.md`).
- **Cursor**: detect `projects/*/agent-transcripts/` *before* Claude's `projects/` so `path='~/.cursor'` is not misread as Claude (empty). Fall back to agent-transcripts when `state.vscdb` returns no rows.
- `source='grok'|'grok-build'` override; percent-decode Grok cwd folder names.

## Local smoke (this machine, DuckDB v1.5.3)
| path | rows | sessions |
|------|------|----------|
| ~/.claude | 223k | 182 |
| ~/.cursor | 6.5k | 42 |
| ~/.grok | 125k | 920 |
| read_plans ~/.grok | 13 | — |

## Test plan
- [ ] `cargo test detect::`
- [ ] `LOAD` extension; `FROM read_conversations(path:='~/.cursor')` non-empty on machines with agent-transcripts
- [ ] `FROM read_conversations(path:='~/.grok')` / `read_plans(path:='~/.grok')`
- [ ] Claude default path still works